### PR TITLE
Fix errors when running tox tests

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -27,14 +27,17 @@ jobs:
       - name: Clone test repo
         run: git clone https://github.com/ceph/s3-tests.git
 
+      - name: List files
+        run: ls -la ${{ github.workspace }}
+
       # Create envs, resolve deps, but don't run tests yet (speeds up failure surfacing)
       - name: Setup test suite (create envs only)
         env:
-          S3TEST_CONF: s3tests.conf
+          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
         run: tox run -vv --notest -c ./s3-tests
 
       - name: Run Tests
         env:
-          S3TEST_CONF: s3tests.conf
+          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
           S3_USE_SIGV4: "True" # We only support v4 signatures
         run: tox run --skip-pkg-install -c ./s3-tests

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install Go
+        uses: actions/setup-go@v5
+
       - name: Upgrade pip + install tox (v4)
         run: |
           python -m pip install --upgrade pip
@@ -36,45 +39,61 @@ jobs:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
         run: tox run -vv --notest -c ./s3-tests
 
+      - name: Launch s3d and save pid
+        run: |
+          nohup go run ./cmd/s3d/main.go > s3d.log 2>&1 &
+          echo $! > s3d.pid
+
       - name: Run test_headers.py
         env:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
           S3_USE_SIGV4: "True" # We only support v4 signatures
         run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_headers.py
-# NOTE: The following tests are currently disabled
-#
-#      - name: Run test_iam.py
-#        env:
-#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
-#          S3_USE_SIGV4: "True" # We only support v4 signatures
-#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_iam.py
-#
-#      - name: Run test_s3.py
-#        env:
-#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
-#          S3_USE_SIGV4: "True" # We only support v4 signatures
-#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py
-#
-#      - name: Run test_s3select.py
-#        env:
-#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
-#          S3_USE_SIGV4: "True" # We only support v4 signatures
-#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3select.py
-#
-#      - name: Run test_sns.py
-#        env:
-#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
-#          S3_USE_SIGV4: "True" # We only support v4 signatures
-#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_sns.py
-#
-#      - name: Run test_sts.py
-#        env:
-#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
-#          S3_USE_SIGV4: "True" # We only support v4 signatures
-#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_sts.py
-#
-#      - name: Run test_utils.py
-#        env:
-#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
-#          S3_USE_SIGV4: "True" # We only support v4 signatures
-#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_utils.py
+
+      # NOTE: The following tests are currently disabled
+      #
+      #      - name: Run test_iam.py
+      #        env:
+      #          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+      #          S3_USE_SIGV4: "True" # We only support v4 signatures
+      #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_iam.py
+      #
+      #      - name: Run test_s3.py
+      #        env:
+      #          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+      #          S3_USE_SIGV4: "True" # We only support v4 signatures
+      #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py
+      #
+      #      - name: Run test_s3select.py
+      #        env:
+      #          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+      #          S3_USE_SIGV4: "True" # We only support v4 signatures
+      #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3select.py
+      #
+      #      - name: Run test_sns.py
+      #        env:
+      #          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+      #          S3_USE_SIGV4: "True" # We only support v4 signatures
+      #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_sns.py
+      #
+      #      - name: Run test_sts.py
+      #        env:
+      #          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+      #          S3_USE_SIGV4: "True" # We only support v4 signatures
+      #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_sts.py
+      #
+      #      - name: Run test_utils.py
+      #        env:
+      #          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+      #          S3_USE_SIGV4: "True" # We only support v4 signatures
+      #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_utils.py
+
+      - name: Kill s3d
+        run: |
+          kill $(cat s3d.pid) || true
+
+      - name: Upload s3d logs as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: s3d-logs
+          path: s3d.log

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -36,8 +36,45 @@ jobs:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
         run: tox run -vv --notest -c ./s3-tests
 
-      - name: Run Tests
+      - name: Run test_headers.py
         env:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
           S3_USE_SIGV4: "True" # We only support v4 signatures
-        run: tox run --skip-pkg-install -c ./s3-tests
+        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_headers.py
+# NOTE: The following tests are currently disabled
+#
+#      - name: Run test_iam.py
+#        env:
+#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+#          S3_USE_SIGV4: "True" # We only support v4 signatures
+#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_iam.py
+#
+#      - name: Run test_s3.py
+#        env:
+#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+#          S3_USE_SIGV4: "True" # We only support v4 signatures
+#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py
+#
+#      - name: Run test_s3select.py
+#        env:
+#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+#          S3_USE_SIGV4: "True" # We only support v4 signatures
+#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3select.py
+#
+#      - name: Run test_sns.py
+#        env:
+#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+#          S3_USE_SIGV4: "True" # We only support v4 signatures
+#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_sns.py
+#
+#      - name: Run test_sts.py
+#        env:
+#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+#          S3_USE_SIGV4: "True" # We only support v4 signatures
+#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_sts.py
+#
+#      - name: Run test_utils.py
+#        env:
+#          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+#          S3_USE_SIGV4: "True" # We only support v4 signatures
+#        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_utils.py

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -43,6 +43,12 @@ jobs:
         run: |
           nohup go run ./cmd/s3d/main.go > s3d.log 2>&1 &
           echo $! > s3d.pid
+          sleep 1
+          if ! kill -0 $(cat s3d.pid); then
+            echo "s3d failed to start. Logs:"
+            cat s3d.log
+            exit 1
+          fi
 
       - name: Run test_headers.py
         env:
@@ -89,10 +95,12 @@ jobs:
       #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_utils.py
 
       - name: Kill s3d
+        if: always()
         run: |
           kill $(cat s3d.pid) || true
 
       - name: Upload s3d logs as artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: s3d-logs

--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -13,6 +13,23 @@ import (
 const (
 	toxAccessKey = "0555b35654ad1656d804"
 	toxSecretKey = "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=="
+
+	altAccessKey = "NOPQRSTUVWXYZABCDEFG"
+	altSecretKey = "nopqrstuvwxyzabcdefghijklmnabcdefghijklm"
+
+	tenantAccessKey = "HIJKLMNOPQRSTUVWXYZA"
+	tenantSecretKey = "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzab"
+)
+
+var (
+	toxKeyPairs = []struct {
+		AccessKey string
+		SecretKey string
+	}{
+		{toxAccessKey, toxSecretKey},
+		{altAccessKey, altSecretKey},
+		{tenantAccessKey, tenantSecretKey},
+	}
 )
 
 func main() {
@@ -21,10 +38,14 @@ func main() {
 		log.Fatalf("failed to create logger: %v", err)
 	}
 	backend := testutils.NewMemoryBackend()
-	err = backend.AddAccessKey(context.Background(), toxAccessKey, toxSecretKey)
-	if err != nil {
-		log.Fatalf("failed to add access key: %v", err)
+
+	for _, pair := range toxKeyPairs {
+		err = backend.AddAccessKey(context.Background(), pair.AccessKey, pair.SecretKey)
+		if err != nil {
+			log.Fatalf("failed to add access key: %v", err)
+		}
 	}
+
 	s3 := s3.New(backend,
 		s3.WithHostBucketBases([]string{"localhost"}),
 		s3.WithLogger(logger))

--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -28,5 +28,5 @@ func main() {
 	s3 := s3.New(backend,
 		s3.WithHostBucketBases([]string{"localhost"}),
 		s3.WithLogger(logger))
-	http.ListenAndServe("localhost:7777", s3)
+	http.ListenAndServe("localhost:8000", s3)
 }

--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -49,5 +49,7 @@ func main() {
 	s3 := s3.New(backend,
 		s3.WithHostBucketBases([]string{"localhost"}),
 		s3.WithLogger(logger))
-	http.ListenAndServe("localhost:8000", s3)
+	if err := http.ListenAndServe("localhost:8000", s3); err != nil {
+		log.Printf("failed to start server: %v", err)
+	}
 }

--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 
@@ -9,12 +10,22 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	toxAccessKey = "0555b35654ad1656d804"
+	toxSecretKey = "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=="
+)
+
 func main() {
 	logger, err := zap.NewDevelopment()
 	if err != nil {
 		log.Fatalf("failed to create logger: %v", err)
 	}
-	s3 := s3.New(testutils.NewMemoryBackend(),
+	backend := testutils.NewMemoryBackend()
+	err = backend.AddAccessKey(context.Background(), toxAccessKey, toxSecretKey)
+	if err != nil {
+		log.Fatalf("failed to add access key: %v", err)
+	}
+	s3 := s3.New(backend,
 		s3.WithHostBucketBases([]string{"localhost"}),
 		s3.WithLogger(logger))
 	http.ListenAndServe("localhost:7777", s3)

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -103,6 +103,7 @@ func (s s3) authMiddleware(handler auth.AuthenticatedHandler) http.Handler {
 
 			akid, err := auth.HandleAuth(req, s.backend, region, time.Now())
 			if err != nil {
+				s.logger.Debug("authentication failed", zap.Error(err))
 				writeErrorResponse(w, err)
 				return
 			}

--- a/s3tests.conf
+++ b/s3tests.conf
@@ -17,7 +17,7 @@ ssl_verify = False
 ## all the buckets created will start with this prefix;
 ## {random} will be filled with random characters to pad
 ## the prefix to 30 characters long, and avoid collisions
-bucket prefix = yournamehere-{random}-
+bucket prefix = s3d-{random}-
 
 # all the iam account resources (users, roles, etc) created
 # will start with this name prefix


### PR DESCRIPTION
This doesn't really cause any tests to pass but makes sure that they at least don't fail for authentication errors.
It also splits up running the tests into separate steps. So right now only the header tests are enabled.