### PR TITLE
Fix header compat tests

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Launch s3d and save pid
         run: |
-          nohup go run ./cmd/s3d/main.go > s3d.log 2>&1 &
+          nohup go run ./cmd/s3d-tox/main.go > s3d.log 2>&1 &
           echo $! > s3d.pid
           sleep 1
           if ! kill -0 $(cat s3d.pid); then

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -55,15 +55,20 @@ jobs:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
           S3_USE_SIGV4: "True" # We only support v4 signatures
 
-        # We ignore tests that require AWSv2 signatures since s3d only supports
-        # v4
-        # We also ignore tests around the "Expect" header since Go's http server
-        # doesn't give us enough control over it. S3 ignores bad Expect headers,
-        # but Go's http server responds with "417 Expectation Failed" instead.
+        # We ignore the following tests
+        # - The ones that require AWSv2 signatures since s3d only supports
+        #   v4
+        # - Tests around the "Expect" header since Go's http server
+        #   doesn't give us enough control over it. S3 ignores bad Expect headers,
+        #   but Go's http server responds with "417 Expectation Failed" instead.
+        # - Tests that are marked as "fails_on_rgw" since they are known to fail
+        #   due to the tests not being able to correctly manipulate request
+        #   headers.
+        # - Tests around ACLs since s3d currently does not implement ACL handling.
         run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_headers.py \
-            -m "not auth_aws2" \
-            -k "not bad_expect"
+            -m "not auth_aws2 and not fails_on_rgw" \
+            -k "not _create_bad_expect_ and not _acl"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
           S3_USE_SIGV4: "True" # We only support v4 signatures
-        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_headers.py
+        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_headers.py -m "not auth_aws2"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -54,7 +54,16 @@ jobs:
         env:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
           S3_USE_SIGV4: "True" # We only support v4 signatures
-        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_headers.py -m "not auth_aws2"
+
+        # We ignore tests that require AWSv2 signatures since s3d only supports
+        # v4
+        # We also ignore tests around the "Expect" header since Go's http server
+        # doesn't give us enough control over it. S3 ignores bad Expect headers,
+        # but Go's http server responds with "417 Expectation Failed" instead.
+        run: |
+          tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_headers.py \
+            -m "not auth_aws2" \
+            -k "not bad_expect"
 
       # NOTE: The following tests are currently disabled
       #

--- a/cmd/s3d-tox/main.go
+++ b/cmd/s3d-tox/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/SiaFoundation/s3d/s3"
+	"github.com/SiaFoundation/s3d/testutils"
+	"go.uber.org/zap"
+)
+
+const (
+	toxAccessKey = "0555b35654ad1656d804"
+	toxSecretKey = "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=="
+
+	altAccessKey = "NOPQRSTUVWXYZABCDEFG"
+	altSecretKey = "nopqrstuvwxyzabcdefghijklmnabcdefghijklm"
+
+	tenantAccessKey = "HIJKLMNOPQRSTUVWXYZA"
+	tenantSecretKey = "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzab"
+)
+
+var (
+	toxKeyPairs = []struct {
+		AccessKey string
+		SecretKey string
+	}{
+		{toxAccessKey, toxSecretKey},
+		{altAccessKey, altSecretKey},
+		{tenantAccessKey, tenantSecretKey},
+	}
+)
+
+func main() {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		log.Fatalf("failed to create logger: %v", err)
+	}
+	backend := testutils.NewMemoryBackend()
+
+	for _, pair := range toxKeyPairs {
+		err = backend.AddAccessKey(context.Background(), pair.AccessKey, pair.SecretKey)
+		if err != nil {
+			log.Fatalf("failed to add access key: %v", err)
+		}
+	}
+
+	s3 := s3.New(backend,
+		s3.WithHostBucketBases([]string{"localhost"}),
+		s3.WithLogger(logger))
+	if err := http.ListenAndServe("localhost:8000", s3); err != nil {
+		log.Printf("failed to start server: %v", err)
+	}
+}

--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -1,55 +1,5 @@
 package main
 
-import (
-	"context"
-	"log"
-	"net/http"
-
-	"github.com/SiaFoundation/s3d/s3"
-	"github.com/SiaFoundation/s3d/testutils"
-	"go.uber.org/zap"
-)
-
-const (
-	toxAccessKey = "0555b35654ad1656d804"
-	toxSecretKey = "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=="
-
-	altAccessKey = "NOPQRSTUVWXYZABCDEFG"
-	altSecretKey = "nopqrstuvwxyzabcdefghijklmnabcdefghijklm"
-
-	tenantAccessKey = "HIJKLMNOPQRSTUVWXYZA"
-	tenantSecretKey = "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzab"
-)
-
-var (
-	toxKeyPairs = []struct {
-		AccessKey string
-		SecretKey string
-	}{
-		{toxAccessKey, toxSecretKey},
-		{altAccessKey, altSecretKey},
-		{tenantAccessKey, tenantSecretKey},
-	}
-)
-
 func main() {
-	logger, err := zap.NewDevelopment()
-	if err != nil {
-		log.Fatalf("failed to create logger: %v", err)
-	}
-	backend := testutils.NewMemoryBackend()
-
-	for _, pair := range toxKeyPairs {
-		err = backend.AddAccessKey(context.Background(), pair.AccessKey, pair.SecretKey)
-		if err != nil {
-			log.Fatalf("failed to add access key: %v", err)
-		}
-	}
-
-	s3 := s3.New(backend,
-		s3.WithHostBucketBases([]string{"localhost"}),
-		s3.WithLogger(logger))
-	if err := http.ListenAndServe("localhost:8000", s3); err != nil {
-		log.Printf("failed to start server: %v", err)
-	}
+	// TODO: implement
 }

--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -84,7 +84,7 @@ func HandleAuth(req *http.Request, store KeyStore, region string, now time.Time)
 	} else if strings.HasPrefix(authHeader, AuthorizationAWS4ECDSAP256SHA256) {
 		return handleAuthV4a(req)
 	} else {
-		return "", s3errs.ErrUnsupportedSignature
+		return "", s3errs.ErrInvalidDigest
 	}
 }
 

--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -84,7 +84,12 @@ func HandleAuth(req *http.Request, store KeyStore, region string, now time.Time)
 	} else if strings.HasPrefix(authHeader, AuthorizationAWS4ECDSAP256SHA256) {
 		return handleAuthV4a(req)
 	} else {
-		return "", s3errs.ErrInvalidDigest
+		// NOTE: S3 does something interesting here. You'd expect AccessDenied,
+		// but for some reason it returns an ErrInvalidDigest with 403. Even
+		// though ErrInvalidDigest is usually returned with a 400.
+		err := s3errs.ErrInvalidDigest
+		err.HTTPStatus = http.StatusForbidden
+		return "", err
 	}
 }
 

--- a/s3/internal/testutil/testutil.go
+++ b/s3/internal/testutil/testutil.go
@@ -61,7 +61,10 @@ func (t *S3Tester) AddAccessKey(tb testing.TB, accessKeyID, secretKey string) *S
 
 // AddObject adds an object to the in-memory S3 backend.
 func (t *S3Tester) AddObject(bucket, object string, data []byte, metadata map[string]string) error {
-	_, err := t.backend.PutObject(context.Background(), accessKeyID, bucket, object, metadata, bytes.NewReader(data), int64(len(data)))
+	_, err := t.backend.PutObject(context.Background(), accessKeyID, bucket, object, bytes.NewReader(data), s3.PutObjectOptions{
+		ContentLength: int64(len(data)),
+		Meta:          metadata,
+	})
 	return err
 }
 
@@ -129,7 +132,8 @@ func (t *S3Tester) GetObject(ctx context.Context, bucket, object string, rnge *s
 		return nil, err
 	}
 	etag := strings.Trim(*resp.ETag, `"`)
-	hash, err := hex.DecodeString(etag)
+	var contentMD5 [16]byte
+	_, err = hex.Decode(contentMD5[:], []byte(etag))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
 	}
@@ -145,7 +149,7 @@ func (t *S3Tester) GetObject(ctx context.Context, bucket, object string, rnge *s
 	}
 	return &s3.Object{
 		Body:         resp.Body,
-		Hash:         hash,
+		ContentMD5:   contentMD5,
 		LastModified: *resp.LastModified,
 		Metadata:     resp.Metadata,
 		Range:        objRange,
@@ -172,7 +176,8 @@ func (t *S3Tester) HeadObject(ctx context.Context, bucket, object string, rnge *
 		return nil, err
 	}
 	etag := strings.Trim(*resp.ETag, `"`)
-	hash, err := hex.DecodeString(etag)
+	var contentMD5 [16]byte
+	_, err = hex.Decode(contentMD5[:], []byte(etag))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
 	}
@@ -187,7 +192,7 @@ func (t *S3Tester) HeadObject(ctx context.Context, bucket, object string, rnge *
 		size = *resp.ContentLength
 	}
 	return &s3.Object{
-		Hash:         hash,
+		ContentMD5:   contentMD5,
 		LastModified: *resp.LastModified,
 		Metadata:     resp.Metadata,
 		Range:        objRange,

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -380,7 +380,7 @@ func (s *s3) putObject(w http.ResponseWriter, r *http.Request, accessKeyID strin
 	var contentMD5 *[16]byte
 	if md5Base64 := r.Header.Get("Content-MD5"); md5Base64 != "" {
 		contentMD5 = new([16]byte)
-		if _, err := base64.StdEncoding.Decode(contentMD5[:], []byte(md5Base64)); err != nil {
+		if n, err := base64.StdEncoding.Decode(contentMD5[:], []byte(md5Base64)); err != nil || n != len(contentMD5) {
 			return s3errs.ErrInvalidDigest
 		}
 	}

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -20,7 +20,7 @@ import (
 // Object represents an S3 object stored on the backend.
 type Object struct {
 	Body         io.ReadCloser
-	Hash         []byte
+	ContentMD5   [16]byte
 	LastModified time.Time
 	Metadata     map[string]string
 	Range        *ObjectRange
@@ -63,6 +63,20 @@ func prefixFromQuery(query url.Values) Prefix {
 	prefix.HasPrefix = prefix.HasPrefix && prefix.Prefix != ""
 	prefix.HasDelimiter = prefix.HasDelimiter && prefix.Delimiter != ""
 	return prefix
+}
+
+// PutObjectResult contains information about the result of a PutObject
+// operation.
+type PutObjectResult struct {
+	// ContentMD5 is the MD5 checksum of the object data.
+	ContentMD5 [16]byte
+}
+
+// PutObjectOptions contains options for a PutObject operation.
+type PutObjectOptions struct {
+	Meta          map[string]string
+	ContentLength int64
+	ContentMD5    *[16]byte
 }
 
 // routeObject handles URLs that contain both a bucket path segment and an
@@ -362,12 +376,25 @@ func (s *s3) putObject(w http.ResponseWriter, r *http.Request, accessKeyID strin
 		return s3errs.ErrMissingContentLength
 	}
 
-	hash, err := s.backend.PutObject(r.Context(), accessKeyID, bucket, object, meta, r.Body, r.ContentLength)
+	// extract Content-MD5 header
+	var contentMD5 *[16]byte
+	if md5Base64 := r.Header.Get("Content-MD5"); md5Base64 != "" {
+		contentMD5 = new([16]byte)
+		if _, err := base64.StdEncoding.Decode(contentMD5[:], []byte(md5Base64)); err != nil {
+			return s3errs.ErrInvalidDigest
+		}
+	}
+
+	res, err := s.backend.PutObject(r.Context(), accessKeyID, bucket, object, r.Body, PutObjectOptions{
+		ContentLength: r.ContentLength,
+		ContentMD5:    contentMD5,
+		Meta:          meta,
+	})
 	if err != nil {
 		return err
 	}
 
-	w.Header().Set("ETag", FormatETag(hash))
+	w.Header().Set("ETag", FormatETag(res.ContentMD5[:]))
 	return nil
 }
 
@@ -606,7 +633,7 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 		w.Header().Set(mk, mv)
 	}
 
-	etag := `"` + hex.EncodeToString(obj.Hash) + `"`
+	etag := FormatETag(obj.ContentMD5[:])
 	w.Header().Set("ETag", etag)
 
 	if r.Header.Get("If-None-Match") == etag {

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -378,7 +378,8 @@ func (s *s3) putObject(w http.ResponseWriter, r *http.Request, accessKeyID strin
 
 	// extract Content-MD5 header
 	var contentMD5 *[16]byte
-	if md5Base64 := r.Header.Get("Content-MD5"); md5Base64 != "" {
+	if _, exists := r.Header["Content-Md5"]; exists {
+		md5Base64 := r.Header.Get("Content-Md5")
 		contentMD5 = new([16]byte)
 		if n, err := base64.StdEncoding.Decode(contentMD5[:], []byte(md5Base64)); err != nil || n != len(contentMD5) {
 			return s3errs.ErrInvalidDigest

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -61,8 +61,8 @@ func TestGetAndHeadObject(t *testing.T) {
 		}
 
 		expected := data[start : end+1]
-		if !bytes.Equal(obj.Hash, hash[:]) {
-			t.Fatal("hash mismatch", obj.Hash, hash[:])
+		if obj.ContentMD5 != hash {
+			t.Fatal("hash mismatch", obj.ContentMD5, hash[:])
 		} else if obj.Size != int64(len(data)) {
 			t.Fatalf("size mismatch: expected %d, got %d", len(data), obj.Size)
 		} else if obj.LastModified.Before(now) {
@@ -173,8 +173,8 @@ func TestPutObject(t *testing.T) {
 	obj, err := s3Tester.GetObject(t.Context(), bucket, object, nil)
 	if err != nil {
 		t.Fatal(err)
-	} else if !bytes.Equal(obj.Hash, hash[:]) {
-		t.Fatal("hash mismatch", obj.Hash, hash[:])
+	} else if obj.ContentMD5 != hash {
+		t.Fatal("hash mismatch", obj.ContentMD5, hash[:])
 	} else if obj.Size != int64(len(data)) {
 		t.Fatalf("size mismatch: expected %d, got %d", len(data), obj.Size)
 	} else if !reflect.DeepEqual(obj.Metadata, metadata) {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -116,8 +116,11 @@ type Backend interface {
 	//   NOTE: Versioning is not supported yet.
 	//
 	// - If the bytes read from 'r' do not match 'contentLength',
-	// [ErrIncompleteBody] must be returned.
-	PutObject(ctx context.Context, accessKeyID string, bucket, object string, meta map[string]string, r io.Reader, contentLength int64) ([]byte, error)
+	//   [ErrIncompleteBody] must be returned.
+	//
+	// - If ContentMD5 is set in opts, and the MD5 checksum of the data read
+	//   from 'r' does not match, [ErrBadDigest] must be returned.
+	PutObject(ctx context.Context, accessKeyID string, bucket, object string, r io.Reader, opts PutObjectOptions) (*PutObjectResult, error)
 }
 
 type s3 struct {

--- a/s3/s3errs/errors.go
+++ b/s3/s3errs/errors.go
@@ -63,7 +63,7 @@ var (
 	ErrInvalidBucketName                              = Error{"InvalidBucketName", "The specified bucket name is not valid.", http.StatusBadRequest}
 	ErrInvalidBucketOwnerAWSAccountID                 = Error{"InvalidBucketOwnerAWSAccountID", "Expected bucket owner must be an AWS account ID.", http.StatusBadRequest}
 	ErrInvalidBucketState                             = Error{"InvalidBucketState", "Request is not valid for the bucket’s current state.", http.StatusConflict}
-	ErrInvalidDigest                                  = Error{"InvalidDigest", "Provided Content-MD5/checksum is not valid.", http.StatusForbidden}
+	ErrInvalidDigest                                  = Error{"InvalidDigest", "Provided Content-MD5/checksum is not valid.", http.StatusBadRequest}
 	ErrInvalidEncryptionAlgorithmError                = Error{"InvalidEncryptionAlgorithmError", "Encryption request is not valid; valid value is AES256.", http.StatusBadRequest}
 	ErrInvalidHostHeader                              = Error{"InvalidHostHeader", "Host headers used the incorrect addressing style.", http.StatusBadRequest}
 	ErrInvalidHttpMethod                              = Error{"InvalidHttpMethod", "Request used an unexpected HTTP method.", http.StatusBadRequest}

--- a/s3/s3errs/errors.go
+++ b/s3/s3errs/errors.go
@@ -63,7 +63,7 @@ var (
 	ErrInvalidBucketName                              = Error{"InvalidBucketName", "The specified bucket name is not valid.", http.StatusBadRequest}
 	ErrInvalidBucketOwnerAWSAccountID                 = Error{"InvalidBucketOwnerAWSAccountID", "Expected bucket owner must be an AWS account ID.", http.StatusBadRequest}
 	ErrInvalidBucketState                             = Error{"InvalidBucketState", "Request is not valid for the bucket’s current state.", http.StatusConflict}
-	ErrInvalidDigest                                  = Error{"InvalidDigest", "Provided Content-MD5/checksum is not valid.", http.StatusBadRequest}
+	ErrInvalidDigest                                  = Error{"InvalidDigest", "Provided Content-MD5/checksum is not valid.", http.StatusForbidden}
 	ErrInvalidEncryptionAlgorithmError                = Error{"InvalidEncryptionAlgorithmError", "Encryption request is not valid; valid value is AES256.", http.StatusBadRequest}
 	ErrInvalidHostHeader                              = Error{"InvalidHostHeader", "Host headers used the incorrect addressing style.", http.StatusBadRequest}
 	ErrInvalidHttpMethod                              = Error{"InvalidHttpMethod", "Request used an unexpected HTTP method.", http.StatusBadRequest}

--- a/testutils/backend.go
+++ b/testutils/backend.go
@@ -233,7 +233,7 @@ func (b *MemoryBackend) PutObject(_ context.Context, accessKeyID, bucket, obj st
 
 	contentMD5 := md5.Sum(data)
 	if opts.ContentMD5 != nil && !bytes.Equal(contentMD5[:], opts.ContentMD5[:]) {
-		return nil, s3errs.ErrInvalidDigest
+		return nil, s3errs.ErrBadDigest
 	}
 
 	bkt.objects[obj] = &object{

--- a/testutils/backend.go
+++ b/testutils/backend.go
@@ -33,7 +33,7 @@ type (
 		data         []byte
 		lastModified time.Time
 		metadata     map[string]string
-		hash         []byte
+		contentMD5   [16]byte
 	}
 )
 
@@ -191,7 +191,7 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 				result.Add(&s3.Content{
 					Key:          obj.name,
 					LastModified: s3.NewContentTime(obj.lastModified),
-					ETag:         s3.FormatETag(obj.hash),
+					ETag:         s3.FormatETag(obj.contentMD5[:]),
 					Size:         int64(len(obj.data)),
 				})
 			}
@@ -213,7 +213,7 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 
 // PutObject puts an object into the specified bucket with the given data and
 // metadata.
-func (b *MemoryBackend) PutObject(_ context.Context, accessKeyID, bucket, obj string, metadata map[string]string, r io.Reader, contentLength int64) ([]byte, error) {
+func (b *MemoryBackend) PutObject(_ context.Context, accessKeyID, bucket, obj string, r io.Reader, opts s3.PutObjectOptions) (*s3.PutObjectResult, error) {
 	bkt, exists := b.buckets[bucket]
 	if !exists {
 		return nil, s3errs.ErrNoSuchBucket
@@ -227,19 +227,25 @@ func (b *MemoryBackend) PutObject(_ context.Context, accessKeyID, bucket, obj st
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
-	} else if len(data) != int(contentLength) {
+	} else if len(data) != int(opts.ContentLength) {
 		return nil, s3errs.ErrIncompleteBody
 	}
-	hash := md5.Sum(data)
-	now := time.Now()
+
+	contentMD5 := md5.Sum(data)
+	if opts.ContentMD5 != nil && !bytes.Equal(contentMD5[:], opts.ContentMD5[:]) {
+		return nil, s3errs.ErrInvalidDigest
+	}
+
 	bkt.objects[obj] = &object{
 		name:         obj,
 		data:         slices.Clone(data),
-		hash:         hash[:],
-		lastModified: now,
-		metadata:     metadata,
+		contentMD5:   contentMD5,
+		lastModified: time.Now(),
+		metadata:     opts.Meta,
 	}
-	return hash[:], nil
+	return &s3.PutObjectResult{
+		ContentMD5: contentMD5,
+	}, nil
 }
 
 // ListBuckets lists all available buckets.
@@ -290,7 +296,7 @@ func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, 
 	}
 	return &s3.Object{
 		Body:         body,
-		Hash:         obj.hash,
+		ContentMD5:   obj.contentMD5,
 		LastModified: obj.lastModified,
 		Metadata:     obj.metadata,
 		Range:        rnge,


### PR DESCRIPTION
This PR makes the `test_headers.py` tests pass by either tweaking our implementation or skipping tests that we know can't or won't be satisfied right now.

It also moves the `s3d/main.go` to `s3d-tox/main.go` to free up `s3d/main.go` for the actual development of `s3d`. 
`s3d-tox` will be used for launching the API for the tox compatibility tests. Right now with the in-memory backend and once we add a Sia backend for that as well. 