### PR TITLE
Add support for `STREAMING-UNSIGNED-PAYLOAD-TRAILER` auth

### DIFF
--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -25,6 +25,13 @@ const (
 	// over HeaderDate.
 	HeaderXAMZDate = "X-Amz-Date"
 
+	// HeaderXAMZDecodedContentLength contains the decoded content length of an
+	// aws-chunked encoded request.
+	HeaderXAMZDecodedContentLength = "X-Amz-Decoded-Content-Length"
+
+	// HeaderXAMZTrailer contains the expected headers of the payload trailer
+	HeaderXAMZTrailer = "X-Amz-Trailer"
+
 	// HeaderDate is the standard HTTP "Date" header. It is used if
 	// HeaderXAMZDate is not present.
 	HeaderDate = "Date"
@@ -108,15 +115,12 @@ func handleAuthV4(req *http.Request, store KeyStore, region string, now time.Tim
 	// case1: payload is not signed at all
 	case ContentUnsignedPayload:
 		return "", s3errs.ErrNotImplemented
-	// case2: payload is not signed and contains a trailer with a checksum
-	case ContentStreamingUnsignedPayloadTrailer:
-		return "", s3errs.ErrNotImplemented
-	// case3: payload is signed using SigV4 chunked encoding
-	case ContentStreamingAWS4HMACSHA256Payload:
-		return "", s3errs.ErrNotImplemented
-	// case4: payload is signed using SigV4 chunked encoding with a trailer
-	case ContentStreamingAWS4HMACSHA256PayloadTrailer:
-		return "", s3errs.ErrNotImplemented
+	// case2-4: payload is streamed and possibly signed or has a trailer with
+	// additional headers
+	case ContentStreamingUnsignedPayloadTrailer,
+		ContentStreamingAWS4HMACSHA256Payload,
+		ContentStreamingAWS4HMACSHA256PayloadTrailer:
+		return accessKeyID, handleAuthV4Streaming(req)
 	// case5: the x-amz-content-sha256 header contains the actual payload hash
 	default:
 		return accessKeyID, nil

--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -114,7 +114,7 @@ func handleAuthV4(req *http.Request, store KeyStore, region string, now time.Tim
 	switch req.Header.Get(HeaderXAMZContentSHA256) {
 	// case1: payload is not signed at all
 	case ContentUnsignedPayload:
-		return "", s3errs.ErrNotImplemented
+		return accessKeyID, nil
 	// case2-4: payload is streamed and possibly signed or has a trailer with
 	// additional headers
 	case ContentStreamingUnsignedPayloadTrailer,

--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -37,6 +37,14 @@ const (
 	HeaderDate = "Date"
 )
 
+// The following constants define the supported checksum header names.
+const (
+	xAmzChecksumCrc32  = "X-Amz-Checksum-Crc32"
+	xAmzChecksumCrc32C = "X-Amz-Checksum-Crc32C"
+	xAmzChecksumSha1   = "X-Amz-Checksum-Sha1"
+	xAmzChecksumSha256 = "X-Amz-Checksum-Sha256"
+)
+
 // The following constants define the supported "Authorization" header values
 const (
 	AuthorizationAWS4HMACSHA256 = "AWS4-HMAC-SHA256" // SigV4

--- a/s3/auth/streaming_v4.go
+++ b/s3/auth/streaming_v4.go
@@ -43,7 +43,7 @@ func handleAuthV4Streaming(req *http.Request) error {
 
 	switch req.Header.Get(HeaderXAMZContentSHA256) {
 	case ContentStreamingUnsignedPayloadTrailer:
-		req.Body = io.NopCloser(newChunkedPayloadTrailerReader(req.Body, expectedHeaders))
+		req.Body = newChunkedPayloadTrailerReader(req.Body, expectedHeaders)
 	case ContentStreamingAWS4HMACSHA256Payload:
 		return s3errs.ErrNotImplemented
 	case ContentStreamingAWS4HMACSHA256PayloadTrailer:
@@ -62,6 +62,7 @@ func handleAuthV4Streaming(req *http.Request) error {
 // It implements io.Reader for the payload bytes.
 type chunkedPayloadTrailerReader struct {
 	br              *bufio.Reader
+	r               io.Closer // io.Closer to avoid reading from it rather than br
 	chunkRemain     int64
 	done            bool
 	expectedHeaders map[string]struct{}
@@ -74,7 +75,7 @@ type chunkedPayloadTrailerReader struct {
 
 // newChunkedPayloadTrailerReader wraps r. r should be the raw HTTP message body
 // with Content-Encoding: aws-chunked.
-func newChunkedPayloadTrailerReader(r io.Reader, expectedHeaders map[string]struct{}) *chunkedPayloadTrailerReader {
+func newChunkedPayloadTrailerReader(r io.ReadCloser, expectedHeaders map[string]struct{}) *chunkedPayloadTrailerReader {
 	var crc32Hasher hash.Hash32
 	if _, exists := expectedHeaders[xAmzChecksumCrc32]; exists {
 		crc32Hasher = crc32.New(crc32.MakeTable(crc32.IEEE))
@@ -93,6 +94,7 @@ func newChunkedPayloadTrailerReader(r io.Reader, expectedHeaders map[string]stru
 	}
 
 	return &chunkedPayloadTrailerReader{
+		r:               r,
 		br:              bufio.NewReader(r),
 		chunkRemain:     0,
 		expectedHeaders: expectedHeaders,
@@ -102,6 +104,11 @@ func newChunkedPayloadTrailerReader(r io.Reader, expectedHeaders map[string]stru
 		sha1Hasher:   sha1Hasher,
 		sha256Hasher: sha256Hasher,
 	}
+}
+
+// Close closes the underlying reader.
+func (r *chunkedPayloadTrailerReader) Close() error {
+	return r.r.Close()
 }
 
 // Read streams only the payload bytes. Once the payload is exhausted,

--- a/s3/auth/streaming_v4.go
+++ b/s3/auth/streaming_v4.go
@@ -2,7 +2,12 @@ package auth
 
 import (
 	"bufio"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
+	"hash"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"strconv"
@@ -24,13 +29,21 @@ func handleAuthV4Streaming(req *http.Request) error {
 		}
 	}
 
-	// TODO: This is where we should check if HeaderXAMZTrailer is set and parse
-	// it. Then we'd add it to the chunked reader to make sure the reader can
-	// validate that the trailer only contains headers previously specified.
+	// parse x-amz-trailer which contains the expected trailer headers
+	xAmzTrailer := req.Header.Get(HeaderXAMZTrailer)
+	if xAmzTrailer == "" {
+		return s3errs.ErrInvalidArgument
+	}
+
+	// parse the headers
+	expectedHeaders := make(map[string]struct{})
+	for h := range strings.SplitSeq(xAmzTrailer, ",") {
+		expectedHeaders[http.CanonicalHeaderKey(h)] = struct{}{}
+	}
 
 	switch req.Header.Get(HeaderXAMZContentSHA256) {
 	case ContentStreamingUnsignedPayloadTrailer:
-		req.Body = io.NopCloser(newChunkedPayloadTrailerReader(req.Body))
+		req.Body = io.NopCloser(newChunkedPayloadTrailerReader(req.Body, expectedHeaders))
 	case ContentStreamingAWS4HMACSHA256Payload:
 		return s3errs.ErrNotImplemented
 	case ContentStreamingAWS4HMACSHA256PayloadTrailer:
@@ -53,18 +66,46 @@ func handleAuthV4Streaming(req *http.Request) error {
 // compare the checksum in the trailer to the computed one and have Read return
 // an appropriate error if there is a mismatch.
 type chunkedPayloadTrailerReader struct {
-	br             *bufio.Reader
-	chunkRemain    int64
-	donePayload    bool
-	trailersParsed bool
+	br              *bufio.Reader
+	chunkRemain     int64
+	donePayload     bool
+	expectedHeaders map[string]struct{}
+
+	crc32Hasher  hash.Hash32
+	crc32CHasher hash.Hash32
+	sha1Hasher   hash.Hash
+	sha256Hasher hash.Hash
 }
 
 // newChunkedPayloadTrailerReader wraps r. r should be the raw HTTP message body
 // with Content-Encoding: aws-chunked.
-func newChunkedPayloadTrailerReader(r io.Reader) *chunkedPayloadTrailerReader {
+func newChunkedPayloadTrailerReader(r io.Reader, expectedHeaders map[string]struct{}) *chunkedPayloadTrailerReader {
+	var crc32Hasher hash.Hash32
+	if _, exists := expectedHeaders[xAmzChecksumCrc32]; exists {
+		crc32Hasher = crc32.New(crc32.MakeTable(crc32.IEEE))
+	}
+	var crc32CHasher hash.Hash32
+	if _, exists := expectedHeaders[xAmzChecksumCrc32C]; exists {
+		crc32CHasher = crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	}
+	var sha1Hasher hash.Hash
+	if _, exists := expectedHeaders[xAmzChecksumSha1]; exists {
+		sha1Hasher = sha1.New()
+	}
+	var sha256Hasher hash.Hash
+	if _, exists := expectedHeaders[xAmzChecksumSha256]; exists {
+		sha256Hasher = sha256.New()
+	}
+
 	return &chunkedPayloadTrailerReader{
-		br:          bufio.NewReader(r),
-		chunkRemain: 0,
+		br:              bufio.NewReader(r),
+		chunkRemain:     0,
+		expectedHeaders: expectedHeaders,
+
+		crc32Hasher:  crc32Hasher,
+		crc32CHasher: crc32CHasher,
+		sha1Hasher:   sha1Hasher,
+		sha256Hasher: sha256Hasher,
 	}
 }
 
@@ -88,7 +129,10 @@ func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
 			return 0, err
 		}
 		if size == 0 {
-			// TODO: This is where the trailer should be parsed
+			_, err := u.assertTrailerHeaders(u.expectedHeaders)
+			if err != nil {
+				return 0, err
+			}
 			return 0, io.EOF
 		}
 		u.chunkRemain = size
@@ -109,6 +153,9 @@ func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
 		return n, err
 	}
 
+	// update hashers with read data
+	u.updateHashers(p[:n])
+
 	// if we just finished this chunk, expect a trailing CRLF.
 	if u.chunkRemain == 0 {
 		if err := expectCRLF(u.br); err != nil {
@@ -116,6 +163,73 @@ func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
 		}
 	}
 	return n, nil
+}
+
+// assertTrailerHeaders reads and asserts trailer headers from br match
+// expectedHeaders.
+func (u *chunkedPayloadTrailerReader) assertTrailerHeaders(expectedHeaders map[string]struct{}) (http.Header, error) {
+	parsedHeaders := make(http.Header)
+
+	for {
+		// read a line from the buffer
+		line, err := readCRLFLine(u.br)
+		if err != nil {
+			return nil, s3errs.ErrInvalidArgument
+		}
+
+		// an empty line indicates the end of the headers
+		if line == "" {
+			break
+		}
+
+		// split the line into key and value
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			return nil, s3errs.ErrInvalidArgument
+		}
+
+		key := http.CanonicalHeaderKey(strings.TrimSpace(parts[0]))
+		value := strings.TrimSpace(parts[1])
+
+		// check if the header is expected
+		if _, ok := expectedHeaders[key]; !ok {
+			return nil, s3errs.ErrInvalidArgument
+		}
+
+		// add the header to the parsed headers
+		parsedHeaders.Add(key, value)
+	}
+
+	// ensure all expected headers are present
+	for expected := range expectedHeaders {
+		h, ok := parsedHeaders[expected]
+		if !ok {
+			return nil, fmt.Errorf("missing expected trailer header: %q", expected)
+		}
+
+		// verify checksum headers
+		if expected == xAmzChecksumCrc32 {
+			if chksum := base64.StdEncoding.EncodeToString(u.crc32Hasher.Sum(nil)); h[0] != chksum {
+				return nil, s3errs.ErrBadDigest
+			}
+		}
+		if expected == xAmzChecksumCrc32C {
+			if chksum := base64.StdEncoding.EncodeToString(u.crc32CHasher.Sum(nil)); h[0] != chksum {
+				return nil, s3errs.ErrBadDigest
+			}
+		}
+		if expected == xAmzChecksumSha1 {
+			if chksum := base64.StdEncoding.EncodeToString(u.sha1Hasher.Sum(nil)); h[0] != chksum {
+				return nil, s3errs.ErrBadDigest
+			}
+		}
+		if expected == xAmzChecksumSha256 {
+			if chksum := base64.StdEncoding.EncodeToString(u.sha256Hasher.Sum(nil)); h[0] != chksum {
+				return nil, s3errs.ErrBadDigest
+			}
+		}
+	}
+	return parsedHeaders, nil
 }
 
 func expectCRLF(br *bufio.Reader) error {
@@ -157,4 +271,21 @@ func readCRLFLine(br *bufio.Reader) (string, error) {
 		return "", fmt.Errorf("malformed chunk header: missing CRLF")
 	}
 	return string(b[:len(b)-2]), nil // strip CRLF
+}
+
+// updateHashers updates all active hashers with data to later verify against
+// trailer checksums.
+func (u *chunkedPayloadTrailerReader) updateHashers(data []byte) {
+	if u.crc32Hasher != nil {
+		_, _ = u.crc32Hasher.Write(data)
+	}
+	if u.crc32CHasher != nil {
+		_, _ = u.crc32CHasher.Write(data)
+	}
+	if u.sha1Hasher != nil {
+		_, _ = u.sha1Hasher.Write(data)
+	}
+	if u.sha256Hasher != nil {
+		_, _ = u.sha256Hasher.Write(data)
+	}
 }

--- a/s3/auth/streaming_v4.go
+++ b/s3/auth/streaming_v4.go
@@ -60,15 +60,10 @@ func handleAuthV4Streaming(req *http.Request) error {
 // chunkedPayloadTrailerReader reads an aws-chunked body where
 // x-amz-content-sha256 = STREAMING-UNSIGNED-PAYLOAD-TRAILER.
 // It implements io.Reader for the payload bytes.
-//
-// TODO: Eventually this should check if any checksum headers are to be expected
-// in the trailer and compute the necessary checksum as we go. Finally it would
-// compare the checksum in the trailer to the computed one and have Read return
-// an appropriate error if there is a mismatch.
 type chunkedPayloadTrailerReader struct {
 	br              *bufio.Reader
 	chunkRemain     int64
-	donePayload     bool
+	done            bool
 	expectedHeaders map[string]struct{}
 
 	crc32Hasher  hash.Hash32
@@ -111,16 +106,16 @@ func newChunkedPayloadTrailerReader(r io.Reader, expectedHeaders map[string]stru
 
 // Read streams only the payload bytes. Once the payload is exhausted,
 // Read returns io.EOF (and trailers will have been parsed).
-func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
+func (r *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
 	// if we already finished payload, signal EOF.
-	if u.donePayload {
+	if r.done {
 		return 0, io.EOF
 	}
 
 	// ensure we have an active chunk to read from.
-	for u.chunkRemain == 0 {
+	for r.chunkRemain == 0 {
 		// Read next chunk-size line: "<hex-size>(;ext...)\r\n"
-		line, err := readCRLFLine(u.br)
+		line, err := readCRLFLine(r.br)
 		if err != nil {
 			return 0, err
 		}
@@ -129,13 +124,14 @@ func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
 			return 0, err
 		}
 		if size == 0 {
-			_, err := u.assertTrailerHeaders(u.expectedHeaders)
+			_, err := r.assertTrailerHeaders(r.expectedHeaders)
 			if err != nil {
 				return 0, err
 			}
+			r.done = true
 			return 0, io.EOF
 		}
-		u.chunkRemain = size
+		r.chunkRemain = size
 	}
 
 	// read up to min(len(p), chunkRemain)
@@ -143,22 +139,22 @@ func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
 	if nwant == 0 {
 		return 0, nil
 	}
-	if nwant > u.chunkRemain {
-		nwant = u.chunkRemain
+	if nwant > r.chunkRemain {
+		nwant = r.chunkRemain
 	}
 
-	n, err := io.ReadFull(u.br, p[:nwant])
-	u.chunkRemain -= int64(n)
+	n, err := io.ReadFull(r.br, p[:nwant])
+	r.chunkRemain -= int64(n)
 	if err != nil {
 		return n, err
 	}
 
 	// update hashers with read data
-	u.updateHashers(p[:n])
+	r.updateHashers(p[:n])
 
 	// if we just finished this chunk, expect a trailing CRLF.
-	if u.chunkRemain == 0 {
-		if err := expectCRLF(u.br); err != nil {
+	if r.chunkRemain == 0 {
+		if err := expectCRLF(r.br); err != nil {
 			return n, err
 		}
 	}
@@ -167,12 +163,12 @@ func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
 
 // assertTrailerHeaders reads and asserts trailer headers from br match
 // expectedHeaders.
-func (u *chunkedPayloadTrailerReader) assertTrailerHeaders(expectedHeaders map[string]struct{}) (http.Header, error) {
+func (r *chunkedPayloadTrailerReader) assertTrailerHeaders(expectedHeaders map[string]struct{}) (http.Header, error) {
 	parsedHeaders := make(http.Header)
 
 	for {
 		// read a line from the buffer
-		line, err := readCRLFLine(u.br)
+		line, err := readCRLFLine(r.br)
 		if err != nil {
 			return nil, s3errs.ErrInvalidArgument
 		}
@@ -209,27 +205,44 @@ func (u *chunkedPayloadTrailerReader) assertTrailerHeaders(expectedHeaders map[s
 
 		// verify checksum headers
 		if expected == xAmzChecksumCrc32 {
-			if chksum := base64.StdEncoding.EncodeToString(u.crc32Hasher.Sum(nil)); h[0] != chksum {
+			if chksum := base64.StdEncoding.EncodeToString(r.crc32Hasher.Sum(nil)); h[0] != chksum {
 				return nil, s3errs.ErrBadDigest
 			}
 		}
 		if expected == xAmzChecksumCrc32C {
-			if chksum := base64.StdEncoding.EncodeToString(u.crc32CHasher.Sum(nil)); h[0] != chksum {
+			if chksum := base64.StdEncoding.EncodeToString(r.crc32CHasher.Sum(nil)); h[0] != chksum {
 				return nil, s3errs.ErrBadDigest
 			}
 		}
 		if expected == xAmzChecksumSha1 {
-			if chksum := base64.StdEncoding.EncodeToString(u.sha1Hasher.Sum(nil)); h[0] != chksum {
+			if chksum := base64.StdEncoding.EncodeToString(r.sha1Hasher.Sum(nil)); h[0] != chksum {
 				return nil, s3errs.ErrBadDigest
 			}
 		}
 		if expected == xAmzChecksumSha256 {
-			if chksum := base64.StdEncoding.EncodeToString(u.sha256Hasher.Sum(nil)); h[0] != chksum {
+			if chksum := base64.StdEncoding.EncodeToString(r.sha256Hasher.Sum(nil)); h[0] != chksum {
 				return nil, s3errs.ErrBadDigest
 			}
 		}
 	}
 	return parsedHeaders, nil
+}
+
+// updateHashers updates all active hashers with data to later verify against
+// trailer checksums.
+func (r *chunkedPayloadTrailerReader) updateHashers(data []byte) {
+	if r.crc32Hasher != nil {
+		_, _ = r.crc32Hasher.Write(data)
+	}
+	if r.crc32CHasher != nil {
+		_, _ = r.crc32CHasher.Write(data)
+	}
+	if r.sha1Hasher != nil {
+		_, _ = r.sha1Hasher.Write(data)
+	}
+	if r.sha256Hasher != nil {
+		_, _ = r.sha256Hasher.Write(data)
+	}
 }
 
 func expectCRLF(br *bufio.Reader) error {
@@ -271,21 +284,4 @@ func readCRLFLine(br *bufio.Reader) (string, error) {
 		return "", fmt.Errorf("malformed chunk header: missing CRLF")
 	}
 	return string(b[:len(b)-2]), nil // strip CRLF
-}
-
-// updateHashers updates all active hashers with data to later verify against
-// trailer checksums.
-func (u *chunkedPayloadTrailerReader) updateHashers(data []byte) {
-	if u.crc32Hasher != nil {
-		_, _ = u.crc32Hasher.Write(data)
-	}
-	if u.crc32CHasher != nil {
-		_, _ = u.crc32CHasher.Write(data)
-	}
-	if u.sha1Hasher != nil {
-		_, _ = u.sha1Hasher.Write(data)
-	}
-	if u.sha256Hasher != nil {
-		_, _ = u.sha256Hasher.Write(data)
-	}
 }

--- a/s3/auth/streaming_v4.go
+++ b/s3/auth/streaming_v4.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/SiaFoundation/s3d/s3/s3errs"
+)
+
+func handleAuthV4Streaming(req *http.Request) error {
+	var size int64
+	if sizeStr, ok := req.Header["X-Amz-Decoded-Content-Length"]; ok {
+		if sizeStr[0] == "" {
+			return s3errs.ErrInvalidArgument
+		}
+		var err error
+		size, err = strconv.ParseInt(sizeStr[0], 10, 64)
+		if err != nil {
+			return s3errs.ErrInvalidArgument
+		}
+	}
+
+	// TODO: This is where we should check if HeaderXAMZTrailer is set and parse
+	// it. Then we'd add it to the chunked reader to make sure the reader can
+	// validate that the trailer only contains headers previously specified.
+
+	switch req.Header.Get(HeaderXAMZContentSHA256) {
+	case ContentStreamingUnsignedPayloadTrailer:
+		req.Body = io.NopCloser(newChunkedPayloadTrailerReader(req.Body))
+	case ContentStreamingAWS4HMACSHA256Payload:
+		return s3errs.ErrNotImplemented
+	case ContentStreamingAWS4HMACSHA256PayloadTrailer:
+		return s3errs.ErrNotImplemented
+	default:
+		// should not reach here
+		return s3errs.ErrInternalError
+	}
+
+	req.ContentLength = size
+	return nil
+}
+
+// chunkedPayloadTrailerReader reads an aws-chunked body where
+// x-amz-content-sha256 = STREAMING-UNSIGNED-PAYLOAD-TRAILER.
+// It implements io.Reader for the payload bytes.
+//
+// TODO: Eventually this should check if any checksum headers are to be expected
+// in the trailer and compute the necessary checksum as we go. Finally it would
+// compare the checksum in the trailer to the computed one and have Read return
+// an appropriate error if there is a mismatch.
+type chunkedPayloadTrailerReader struct {
+	br             *bufio.Reader
+	chunkRemain    int64
+	donePayload    bool
+	trailersParsed bool
+}
+
+// newChunkedPayloadTrailerReader wraps r. r should be the raw HTTP message body
+// with Content-Encoding: aws-chunked.
+func newChunkedPayloadTrailerReader(r io.Reader) *chunkedPayloadTrailerReader {
+	return &chunkedPayloadTrailerReader{
+		br:          bufio.NewReader(r),
+		chunkRemain: 0,
+	}
+}
+
+// Read streams only the payload bytes. Once the payload is exhausted,
+// Read returns io.EOF (and trailers will have been parsed).
+func (u *chunkedPayloadTrailerReader) Read(p []byte) (int, error) {
+	// if we already finished payload, signal EOF.
+	if u.donePayload {
+		return 0, io.EOF
+	}
+
+	// ensure we have an active chunk to read from.
+	for u.chunkRemain == 0 {
+		// Read next chunk-size line: "<hex-size>(;ext...)\r\n"
+		line, err := readCRLFLine(u.br)
+		if err != nil {
+			return 0, err
+		}
+		size, err := parseChunkSize(line)
+		if err != nil {
+			return 0, err
+		}
+		if size == 0 {
+			// TODO: This is where the trailer should be parsed
+			return 0, io.EOF
+		}
+		u.chunkRemain = size
+	}
+
+	// read up to min(len(p), chunkRemain)
+	nwant := int64(len(p))
+	if nwant == 0 {
+		return 0, nil
+	}
+	if nwant > u.chunkRemain {
+		nwant = u.chunkRemain
+	}
+
+	n, err := io.ReadFull(u.br, p[:nwant])
+	u.chunkRemain -= int64(n)
+	if err != nil {
+		return n, err
+	}
+
+	// if we just finished this chunk, expect a trailing CRLF.
+	if u.chunkRemain == 0 {
+		if err := expectCRLF(u.br); err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func expectCRLF(br *bufio.Reader) error {
+	b, err := br.Peek(2)
+	if err != nil {
+		return err
+	}
+	if len(b) < 2 || b[0] != '\r' || b[1] != '\n' {
+		return fmt.Errorf("malformed chunk: missing CRLF after data")
+	}
+	_, _ = br.Discard(2)
+	return nil
+}
+
+func parseChunkSize(line string) (int64, error) {
+	// chunk size may have extensions: "ABC;foo=bar"
+	sz := line
+	if i := strings.IndexByte(line, ';'); i >= 0 {
+		sz = line[:i]
+	}
+	sz = strings.TrimSpace(sz)
+	if sz == "" {
+		return 0, fmt.Errorf("empty chunk size")
+	}
+	n, err := strconv.ParseInt(sz, 16, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid chunk size %q: %w", sz, err)
+	}
+	return n, nil
+}
+
+func readCRLFLine(br *bufio.Reader) (string, error) {
+	// read until '\n' and ensure it ends with "\r\n".
+	b, err := br.ReadBytes('\n')
+	if err != nil {
+		return "", err
+	}
+	if len(b) < 2 || b[len(b)-2] != '\r' {
+		return "", fmt.Errorf("malformed chunk header: missing CRLF")
+	}
+	return string(b[:len(b)-2]), nil // strip CRLF
+}

--- a/s3/internal/testutil/testutil.go
+++ b/s3/internal/testutil/testutil.go
@@ -6,8 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"net"
-	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
@@ -276,6 +275,16 @@ func (t *S3Tester) PutObject(ctx context.Context, bucket, object string, r io.Re
 // NewTester creates a new S3Tester with an in-memory S3 backend and an AWS
 // client configured to talk to it.
 func NewTester(t testing.TB, optFns ...func(*service.Options)) *S3Tester {
+	return newTester(t, false, optFns...)
+}
+
+// NewTester creates a new S3Tester with an in-memory S3 backend and an AWS
+// client configured to talk to it over TLS.
+func NewTesterTLS(t testing.TB, optFns ...func(*service.Options)) *S3Tester {
+	return newTester(t, true, optFns...)
+}
+
+func newTester(t testing.TB, tls bool, optFns ...func(*service.Options)) *S3Tester {
 	t.Helper()
 
 	backend := testutils.NewMemoryBackend()
@@ -286,16 +295,14 @@ func NewTester(t testing.TB, optFns ...func(*service.Options)) *S3Tester {
 	handler := s3.New(backend,
 		s3.WithHostBucketBases([]string{"localhost"}),
 		s3.WithLogger(zaptest.NewLogger(t)))
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	go func() {
-		http.Serve(listener, handler)
-	}()
 
-	listenerAddr := listener.Addr().String()
-	_, port, _ := net.SplitHostPort(listenerAddr)
+	server := httptest.NewUnstartedServer(handler)
+	if tls {
+		server.StartTLS()
+	} else {
+		server.Start()
+	}
+	t.Cleanup(server.Close)
 
 	cfg, err := config.LoadDefaultConfig(t.Context())
 	if err != nil {
@@ -305,7 +312,8 @@ func NewTester(t testing.TB, optFns ...func(*service.Options)) *S3Tester {
 	opts := []func(*service.Options){
 		func(o *service.Options) {
 			o.Region = "us-east-1"
-			o.BaseEndpoint = aws.String(fmt.Sprintf("http://localhost:%s", port))
+			o.HTTPClient = server.Client()
+			o.BaseEndpoint = &server.URL
 			o.UsePathStyle = true
 			o.Credentials = aws.NewCredentialsCache(&credentials.StaticCredentialsProvider{
 				Value: aws.Credentials{

--- a/s3/internal/testutil/testutil.go
+++ b/s3/internal/testutil/testutil.go
@@ -275,16 +275,16 @@ func (t *S3Tester) PutObject(ctx context.Context, bucket, object string, r io.Re
 // NewTester creates a new S3Tester with an in-memory S3 backend and an AWS
 // client configured to talk to it.
 func NewTester(t testing.TB, optFns ...func(*service.Options)) *S3Tester {
-	return newTester(t, false, optFns...)
+	return newTesterWithTLS(t, false, optFns...)
 }
 
-// NewTester creates a new S3Tester with an in-memory S3 backend and an AWS
+// NewTesterTLS creates a new S3Tester with an in-memory S3 backend and an AWS
 // client configured to talk to it over TLS.
 func NewTesterTLS(t testing.TB, optFns ...func(*service.Options)) *S3Tester {
-	return newTester(t, true, optFns...)
+	return newTesterWithTLS(t, true, optFns...)
 }
 
-func newTester(t testing.TB, tls bool, optFns ...func(*service.Options)) *S3Tester {
+func newTesterWithTLS(t testing.TB, tls bool, optFns ...func(*service.Options)) *S3Tester {
 	t.Helper()
 
 	backend := testutils.NewMemoryBackend()

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -145,60 +145,71 @@ func TestGetAndHeadObject(t *testing.T) {
 }
 
 func TestPutObject(t *testing.T) {
-	s3Tester := testutil.NewTester(t)
+	test := func(t *testing.T, s3Tester *testutil.S3Tester) {
+		data := frand.Bytes(100)
+		hash := md5.Sum(data)
 
-	// prepare a bucket
-	bucket := "foo"
-	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
-		t.Fatal(err)
+		// prepare a bucket
+		bucket := "foo"
+		if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+			t.Fatal(err)
+		}
+
+		// prepare the object to upload
+		object := "bar"
+		metadata := map[string]string{
+			"foo": "bar",
+		}
+
+		// upload the object
+		resp, err := s3Tester.PutObject(t.Context(), bucket, object, bytes.NewReader(data), metadata)
+		if err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(resp, hash[:]) {
+			t.Fatalf("hash mismatch: expected %x, got %x", hash, resp)
+		}
+
+		// download the object and verify it
+		obj, err := s3Tester.GetObject(t.Context(), bucket, object, nil)
+		if err != nil {
+			t.Fatal(err)
+		} else if obj.ContentMD5 != hash {
+			t.Fatal("hash mismatch", obj.ContentMD5, hash[:])
+		} else if obj.Size != int64(len(data)) {
+			t.Fatalf("size mismatch: expected %d, got %d", len(data), obj.Size)
+		} else if !reflect.DeepEqual(obj.Metadata, metadata) {
+			t.Fatal("metadata mismatch", obj.Metadata)
+		}
+
+		// upload with a key that is too large
+		_, err = s3Tester.PutObject(t.Context(), bucket, hex.EncodeToString(frand.Bytes(s3.KeySizeLimit)), bytes.NewReader(data), nil)
+		testutil.AssertS3Error(t, s3errs.ErrKeyTooLongError, err)
+
+		// upload with metadata that is too large
+		_, err = s3Tester.PutObject(t.Context(), bucket, "too-much-meta", bytes.NewReader(data), map[string]string{
+			"too-much": hex.EncodeToString(frand.Bytes(s3.MetadataSizeLimit)),
+		})
+		testutil.AssertS3Error(t, s3errs.ErrMetadataTooLarge, err)
+
+		// upload to a bucket that doesn't exist
+		_, err = s3Tester.PutObject(t.Context(), "nonexistent", object, bytes.NewReader(data), metadata)
+		testutil.AssertS3Error(t, s3errs.ErrNoSuchBucket, err)
+
+		// upload to a bucket that we don't own
+		otherTester := s3Tester.AddAccessKey(t, "foo", "bar")
+		_, err = otherTester.PutObject(t.Context(), bucket, object, bytes.NewReader(data), metadata)
+		testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
 	}
 
-	// prepare the object to upload
-	data := frand.Bytes(100)
-	hash := md5.Sum(data)
-	object := "bar"
-	metadata := map[string]string{
-		"foo": "bar",
-	}
-
-	// upload the object
-	resp, err := s3Tester.PutObject(t.Context(), bucket, object, bytes.NewReader(data), metadata)
-	if err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(resp, hash[:]) {
-		t.Fatalf("hash mismatch: expected %x, got %x", hash, resp)
-	}
-
-	// download the object and verify it
-	obj, err := s3Tester.GetObject(t.Context(), bucket, object, nil)
-	if err != nil {
-		t.Fatal(err)
-	} else if obj.ContentMD5 != hash {
-		t.Fatal("hash mismatch", obj.ContentMD5, hash[:])
-	} else if obj.Size != int64(len(data)) {
-		t.Fatalf("size mismatch: expected %d, got %d", len(data), obj.Size)
-	} else if !reflect.DeepEqual(obj.Metadata, metadata) {
-		t.Fatal("metadata mismatch", obj.Metadata)
-	}
-
-	// upload with a key that is too large
-	_, err = s3Tester.PutObject(t.Context(), bucket, hex.EncodeToString(frand.Bytes(s3.KeySizeLimit)), bytes.NewReader(data), nil)
-	testutil.AssertS3Error(t, s3errs.ErrKeyTooLongError, err)
-
-	// upload with metadata that is too large
-	_, err = s3Tester.PutObject(t.Context(), bucket, "too-much-meta", bytes.NewReader(data), map[string]string{
-		"too-much": hex.EncodeToString(frand.Bytes(s3.MetadataSizeLimit)),
+	t.Run("http", func(t *testing.T) {
+		s3Tester := testutil.NewTester(t)
+		test(t, s3Tester)
 	})
-	testutil.AssertS3Error(t, s3errs.ErrMetadataTooLarge, err)
 
-	// upload to a bucket that doesn't exist
-	_, err = s3Tester.PutObject(t.Context(), "nonexistent", object, bytes.NewReader(data), metadata)
-	testutil.AssertS3Error(t, s3errs.ErrNoSuchBucket, err)
-
-	// upload to a bucket that we don't own
-	otherTester := s3Tester.AddAccessKey(t, "foo", "bar")
-	_, err = otherTester.PutObject(t.Context(), bucket, object, bytes.NewReader(data), metadata)
-	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+	t.Run("https", func(t *testing.T) {
+		s3Tester := testutil.NewTesterTLS(t)
+		test(t, s3Tester)
+	})
 }
 
 func TestRangeRequest(t *testing.T) {


### PR DESCRIPTION
Which seems to be the default for the AWS v2 Go SDK when https is used