### PR TITLE
Validate `x-amz-content-sha256` checksum if present

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -43,12 +43,16 @@ jobs:
         run: |
           nohup go run ./cmd/s3d-tox/main.go > s3d.log 2>&1 &
           echo $! > s3d.pid
-          sleep 1
-          if ! kill -0 $(cat s3d.pid); then
-            echo "s3d failed to start. Logs:"
-            cat s3d.log
-            exit 1
-          fi
+
+          # wait a bit to let s3d start
+          for i in {1..10}; do
+            if kill -0 $(cat s3d.pid); then
+              sleep 1
+              if nc -z localhost 8000; then
+                break
+              fi
+            fi
+          done
 
       - name: Run test_headers.py
         env:

--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/hex"
 	"net/http"
 	"strings"
 	"time"
@@ -95,21 +96,56 @@ func HandleAuth(req *http.Request, store KeyStore, region string, now time.Time)
 
 // handleAuthV4 handles AWS Signature Version 4 authentication using HMAC.
 func handleAuthV4(req *http.Request, store KeyStore, region string, now time.Time) (string, error) {
+	// verify the signed request first
+	accessKeyID, err := verifyV4SignedRequest(req, store, region, now)
+	if err != nil {
+		return "", err
+	}
+
+	// at this point the signature is valid, but we still need to check if the
+	// signed payload matches
 	switch req.Header.Get(HeaderXAMZContentSHA256) {
+	// case1: payload is not signed at all
 	case ContentUnsignedPayload:
 		return "", s3errs.ErrNotImplemented
+	// case2: payload is not signed and contains a trailer with a checksum
 	case ContentStreamingUnsignedPayloadTrailer:
 		return "", s3errs.ErrNotImplemented
+	// case3: payload is signed using SigV4 chunked encoding
 	case ContentStreamingAWS4HMACSHA256Payload:
 		return "", s3errs.ErrNotImplemented
+	// case4: payload is signed using SigV4 chunked encoding with a trailer
 	case ContentStreamingAWS4HMACSHA256PayloadTrailer:
 		return "", s3errs.ErrNotImplemented
+	// case5: the x-amz-content-sha256 header contains the actual payload hash
 	default:
-		return verifyV4SimpleSignature(req, store, region, now)
+		return accessKeyID, nil
 	}
 }
 
 // handleAuthV4a handles AWS Signature Version 4A authentication using ECDSA.
 func handleAuthV4a(_ *http.Request) (string, error) {
 	return "", s3errs.ErrNotImplemented // Signature Version 4A is not implemented
+}
+
+// Sha256HashFromRequest extracts the SHA256 hash of the payload from the
+// request if available. This hash should then be used to verify the integrity
+// of the payload.
+func Sha256HashFromRequest(req *http.Request) (*[32]byte, error) {
+	h := req.Header.Get(HeaderXAMZContentSHA256)
+	switch h {
+	case ContentUnsignedPayload,
+		ContentStreamingUnsignedPayloadTrailer,
+		ContentStreamingAWS4HMACSHA256Payload,
+		ContentStreamingAWS4HMACSHA256PayloadTrailer:
+		return nil, nil
+	default:
+	}
+	hash, err := hex.DecodeString(h)
+	if err != nil {
+		return nil, s3errs.ErrInvalidDigest
+	} else if len(hash) != 32 {
+		return nil, s3errs.ErrInvalidDigest
+	}
+	return (*[32]byte)(hash), nil
 }

--- a/s3/auth/auth_v4.go
+++ b/s3/auth/auth_v4.go
@@ -179,7 +179,7 @@ func sumHMAC(key []byte, data []byte) []byte {
 	return hash.Sum(nil)
 }
 
-func verifyV4SimpleSignature(req *http.Request, store KeyStore, region string, now time.Time) (string, error) {
+func verifyV4SignedRequest(req *http.Request, store KeyStore, region string, now time.Time) (string, error) {
 	// for the simple signature, we expect the full payload hash to be provided
 	// in the header
 	payloadHash := req.Header.Get(HeaderXAMZContentSHA256)

--- a/s3/auth/auth_v4_test.go
+++ b/s3/auth/auth_v4_test.go
@@ -67,40 +67,40 @@ func TestDateValidation(t *testing.T) {
 	store := &mockKeyStore{}
 
 	// Case 1: date not set
-	_, err := verifyV4SimpleSignature(req, store, "", now)
+	_, err := verifyV4SignedRequest(req, store, "", now)
 	if !errors.Is(err, s3errs.ErrMissingAuthenticationToken) {
 		t.Fatalf("expected ErrMissingAuthenticationToken, got %v", err)
 	}
 
 	// Case 2: credential date is in the past
 	header.Set(HeaderXAMZDate, now.Add(-24*time.Hour).Format(layoutISO8601))
-	_, err = verifyV4SimpleSignature(req, store, "", now)
+	_, err = verifyV4SignedRequest(req, store, "", now)
 	if !errors.Is(err, s3errs.ErrAuthorizationHeaderMalformed) {
 		t.Fatalf("expected ErrAuthorizationHeaderMalformed, got %v", err)
 	}
 
 	// Case 3: credential date is in the future
 	header.Set(HeaderXAMZDate, now.Add(24*time.Hour).Format(layoutISO8601))
-	_, err = verifyV4SimpleSignature(req, store, "", now)
+	_, err = verifyV4SignedRequest(req, store, "", now)
 	if !errors.Is(err, s3errs.ErrAuthorizationHeaderMalformed) {
 		t.Fatalf("expected ErrAuthorizationHeaderMalformed, got %v", err)
 	}
 
 	// Case 4: date is skewed too far in the past
 	header.Set(HeaderXAMZDate, now.Format(layoutISO8601))
-	_, err = verifyV4SimpleSignature(req, store, "", now.Add(6*time.Minute))
+	_, err = verifyV4SignedRequest(req, store, "", now.Add(6*time.Minute))
 	if !errors.Is(err, s3errs.ErrRequestTimeTooSkewed) {
 		t.Fatalf("expected ErrAuthorizationHeaderMalformed, got %v", err)
 	}
 
 	// Case 5: date is skewed too far in the future
-	_, err = verifyV4SimpleSignature(req, store, "", now.Add(-6*time.Minute))
+	_, err = verifyV4SignedRequest(req, store, "", now.Add(-6*time.Minute))
 	if !errors.Is(err, s3errs.ErrRequestTimeTooSkewed) {
 		t.Fatalf("expected ErrAuthorizationHeaderMalformed, got %v", err)
 	}
 
 	// Case 6: date is valid but we don't have the access key
-	_, err = verifyV4SimpleSignature(req, store, "", now)
+	_, err = verifyV4SignedRequest(req, store, "", now)
 	if !errors.Is(err, s3errs.ErrInvalidAccessKeyId) {
 		t.Fatal(err)
 	}

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SiaFoundation/s3d/s3/auth"
 	"github.com/SiaFoundation/s3d/s3/s3errs"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.uber.org/zap"
@@ -73,10 +74,15 @@ type PutObjectResult struct {
 }
 
 // PutObjectOptions contains options for a PutObject operation.
+//
+// ContentMD5 and ContentSHA256 are optional checksums of the object data. If
+// set, the backend needs to validate the data against the provided checksums
+// and return an error if they don't match.
 type PutObjectOptions struct {
 	Meta          map[string]string
 	ContentLength int64
 	ContentMD5    *[16]byte
+	ContentSHA256 *[32]byte
 }
 
 // routeObject handles URLs that contain both a bucket path segment and an
@@ -386,9 +392,16 @@ func (s *s3) putObject(w http.ResponseWriter, r *http.Request, accessKeyID strin
 		}
 	}
 
+	// extract SHA256 checksum from "X-Amz-Content-Sha256" header if present
+	contentSHA256, err := auth.Sha256HashFromRequest(r)
+	if err != nil {
+		return err
+	}
+
 	res, err := s.backend.PutObject(r.Context(), accessKeyID, bucket, object, r.Body, PutObjectOptions{
 		ContentLength: r.ContentLength,
 		ContentMD5:    contentMD5,
+		ContentSHA256: contentSHA256,
 		Meta:          meta,
 	})
 	if err != nil {

--- a/testutils/backend.go
+++ b/testutils/backend.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"crypto/sha256"
 	"errors"
 	"io"
 	"maps"
@@ -233,6 +234,10 @@ func (b *MemoryBackend) PutObject(_ context.Context, accessKeyID, bucket, obj st
 
 	contentMD5 := md5.Sum(data)
 	if opts.ContentMD5 != nil && !bytes.Equal(contentMD5[:], opts.ContentMD5[:]) {
+		return nil, s3errs.ErrBadDigest
+	}
+	contentSHA256 := sha256.Sum256(data)
+	if opts.ContentSHA256 != nil && *opts.ContentSHA256 != contentSHA256 {
 		return nil, s3errs.ErrBadDigest
 	}
 

--- a/testutils/backend.go
+++ b/testutils/backend.go
@@ -233,7 +233,7 @@ func (b *MemoryBackend) PutObject(_ context.Context, accessKeyID, bucket, obj st
 	}
 
 	contentMD5 := md5.Sum(data)
-	if opts.ContentMD5 != nil && !bytes.Equal(contentMD5[:], opts.ContentMD5[:]) {
+	if opts.ContentMD5 != nil && *opts.ContentMD5 != contentMD5 {
 		return nil, s3errs.ErrBadDigest
 	}
 	contentSHA256 := sha256.Sum256(data)


### PR DESCRIPTION
So far we have validated the signature on the signed request but not the payload in case the `x-amz-content-sha256` header contains the actual payload.