### PR TITLE
Enable and fix compatibility tests for v2 object listing

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -80,7 +80,8 @@ jobs:
           S3_USE_SIGV4: "True" # We only support v4 signatures
         run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
-            -k "test_bucket_listv2 and not delimiter_percentage and not delimiter_whitespace"
+            -k "test_bucket_listv2 and not delimiter_percentage and not delimiter_whitespace \
+                and not delimiter_alt and not delimiter_dot"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -28,7 +28,7 @@ jobs:
           python -m pip install "tox>=4"
 
       - name: Clone test repo
-        run: git clone https://github.com/ceph/s3-tests.git
+        run: git clone https://github.com/SiaFoundation/s3-tests.git
 
       - name: List files
         run: ls -la ${{ github.workspace }}
@@ -80,10 +80,7 @@ jobs:
           S3_USE_SIGV4: "True" # We only support v4 signatures
         run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
-            -k "test_bucket_listv2 and not delimiter_percentage and not delimiter_whitespace \
-                and not delimiter_alt and not delimiter_dot and not delimiter_unreadable \
-                and not delimiter_not_exist and not delimiter_prefix_not_exist \
-                and not bucket_listv2_objects_anonymous"
+            -m "list_objects_v2 and not acl and not bucket_policy and not lifecycle"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -74,6 +74,14 @@ jobs:
             -m "not auth_aws2 and not fails_on_rgw" \
             -k "not _create_bad_expect_ and not _acl"
 
+      - name: Run test_s3.py
+        env:
+          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
+          S3_USE_SIGV4: "True" # We only support v4 signatures
+        run:
+          tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
+          -k "test_bucket_listv2"
+
       # NOTE: The following tests are currently disabled
       #
       #      - name: Run test_iam.py
@@ -82,11 +90,6 @@ jobs:
       #          S3_USE_SIGV4: "True" # We only support v4 signatures
       #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_iam.py
       #
-      #      - name: Run test_s3.py
-      #        env:
-      #          S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
-      #          S3_USE_SIGV4: "True" # We only support v4 signatures
-      #        run: tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py
       #
       #      - name: Run test_s3select.py
       #        env:

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -82,7 +82,8 @@ jobs:
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
             -k "test_bucket_listv2 and not delimiter_percentage and not delimiter_whitespace \
                 and not delimiter_alt and not delimiter_dot and not delimiter_unreadable \
-                and not delimiter_not_exist and not delimiter_prefix_not_exist"
+                and not delimiter_not_exist and not delimiter_prefix_not_exist \
+                and not bucket_listv2_objects_anonymous"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -80,7 +80,7 @@ jobs:
           S3_USE_SIGV4: "True" # We only support v4 signatures
         run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
-            -m "list_objects_v2 and not acl and not bucket_policy and not lifecycle"
+            -m "list_objects_v2 and not s3d_not_implemented and not s3d_not_supported"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -81,7 +81,8 @@ jobs:
         run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
             -k "test_bucket_listv2 and not delimiter_percentage and not delimiter_whitespace \
-                and not delimiter_alt and not delimiter_dot"
+                and not delimiter_alt and not delimiter_dot and not delimiter_unreadable \
+                and not delimiter_not_exist and not delimiter_prefix_not_exist"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -78,9 +78,9 @@ jobs:
         env:
           S3TEST_CONF: ${{ github.workspace }}/s3tests.conf
           S3_USE_SIGV4: "True" # We only support v4 signatures
-        run:
+        run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
-          -k "test_bucket_listv2"
+            -k "test_bucket_listv2 and not delimiter_percentage and not delimiter_whitespace"
 
       # NOTE: The following tests are currently disabled
       #

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -73,6 +73,10 @@ func (s *s3) createBucket(w http.ResponseWriter, r *http.Request, accessKeyID, b
 	q := r.URL.Query()
 	if _, hasACL := q["acl"]; hasACL {
 		return s3errs.ErrNotImplemented // ACLs are not implemented
+	} else if _, hasPolicy := q["policy"]; hasPolicy {
+		return s3errs.ErrNotImplemented // Bucket policies are not implemented
+	} else if _, hasLifecycle := q["lifecycle"]; hasLifecycle {
+		return s3errs.ErrNotImplemented // Bucket lifecycles are not implemented
 	}
 
 	if err := s.backend.CreateBucket(r.Context(), accessKeyID, bucket); err != nil {

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -70,6 +70,11 @@ func (s *s3) createBucket(w http.ResponseWriter, r *http.Request, accessKeyID, b
 		return err
 	}
 
+	q := r.URL.Query()
+	if _, hasACL := q["acl"]; hasACL {
+		return s3errs.ErrNotImplemented // ACLs are not implemented
+	}
+
 	if err := s.backend.CreateBucket(r.Context(), accessKeyID, bucket); err != nil {
 		return err
 	}

--- a/s3/messages.go
+++ b/s3/messages.go
@@ -93,7 +93,7 @@ type (
 
 		// If ContinuationToken was sent with the request, it is included in the
 		// response.
-		ContinuationToken string `xml:"ContinuationToken,omitempty"`
+		ContinuationToken *string `xml:"ContinuationToken,omitempty"`
 
 		// Returns the number of keys included in the response. The value is always
 		// less than or equal to the MaxKeys value.

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -394,7 +394,7 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 	}
 
 	// if fetch-owner is not set, redact owner information
-	if fo := r.Header.Get("fetch-owner"); fo == "false" || fo == "" {
+	if fo, set := r.Form["fetch-owner"]; !set || fo[0] == "false" {
 		for _, v := range result.Contents {
 			v.Owner = nil
 		}

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -377,7 +377,7 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 
 	// continuation token should be omitted if not set, but if it is set to an
 	// empty string, it should still be included.
-	var continuationToken *string = nil
+	var continuationToken *string
 	if _, hasToken := q["continuation-token"]; hasToken {
 		token := q.Get("continuation-token")
 		continuationToken = &token
@@ -407,7 +407,7 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 	}
 
 	// if fetch-owner is not set, redact owner information
-	if fo, set := q["fetch-owner"]; !set || fo[0] == "false" {
+	if fo, set := q["fetch-owner"]; !set || (len(fo) > 0 && fo[0] == "false") {
 		for _, v := range result.Contents {
 			v.Owner = nil
 		}

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -394,7 +394,7 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 	}
 
 	// if fetch-owner is not set, redact owner information
-	if _, ok := q["fetch-owner"]; !ok {
+	if fo := r.Header.Get("fetch-owner"); fo == "false" || fo == "" {
 		for _, v := range result.Contents {
 			v.Owner = nil
 		}

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -375,6 +375,14 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 		}
 	}
 
+	// continuation token should be omitted if not set, but if it is set to an
+	// empty string, it should still be included.
+	var continuationToken *string = nil
+	if _, hasToken := q["continuation-token"]; hasToken {
+		token := q.Get("continuation-token")
+		continuationToken = &token
+	}
+
 	// prepare result
 	var result = &ListObjectsV2Result{
 		ListObjectsResultBase: ListObjectsResultBase{
@@ -389,7 +397,7 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 		},
 		KeyCount:          int64(len(objects.CommonPrefixes) + len(objects.Contents)),
 		StartAfter:        q.Get("start-after"),
-		ContinuationToken: q.Get("continuation-token"),
+		ContinuationToken: continuationToken,
 	}
 	if objects.NextMarker != "" {
 		// S3 continuation tokens are opaque base64-like values, so we just

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -296,17 +296,27 @@ type ObjectsListResult struct {
 	// This is a convenience for backend implementers like s3bolt and s3mem,
 	// which operate on a full, flat list of keys.
 	prefixes map[string]bool
+	maxKeys  int64
 }
 
 // NewObjectsListResult creates a new, empty ObjectsListResult. Use Add and
 // AddPrefix to populate it.
-func NewObjectsListResult() *ObjectsListResult {
-	return &ObjectsListResult{}
+func NewObjectsListResult(maxKeys int64) *ObjectsListResult {
+	return &ObjectsListResult{maxKeys: maxKeys}
 }
 
 // Add adds an object to the result.
 func (b *ObjectsListResult) Add(item *Content) {
-	b.Contents = append(b.Contents, item)
+	if len(b.Contents)+len(b.CommonPrefixes) < int(b.maxKeys) {
+		b.Contents = append(b.Contents, item)
+	}
+	if len(b.Contents)+len(b.CommonPrefixes) >= int(b.maxKeys) {
+		if b.NextMarker == "" {
+			b.NextMarker = item.Key
+		} else {
+			b.IsTruncated = true
+		}
+	}
 }
 
 // AddPrefix adds a common prefix to the result. If the prefix has already been
@@ -317,8 +327,17 @@ func (b *ObjectsListResult) AddPrefix(prefix string) {
 	} else if b.prefixes[prefix] {
 		return
 	}
-	b.prefixes[prefix] = true
-	b.CommonPrefixes = append(b.CommonPrefixes, CommonPrefix{Prefix: prefix})
+	if len(b.Contents)+len(b.CommonPrefixes) < int(b.maxKeys) {
+		b.prefixes[prefix] = true
+		b.CommonPrefixes = append(b.CommonPrefixes, CommonPrefix{Prefix: prefix})
+	}
+	if len(b.Contents)+len(b.CommonPrefixes) >= int(b.maxKeys) {
+		if b.NextMarker == "" {
+			b.NextMarker = prefix
+		} else {
+			b.IsTruncated = true
+		}
+	}
 }
 
 func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *string, bucket string) error {
@@ -337,6 +356,16 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 	objects, err := s.backend.ListObjects(r.Context(), accessKeyID, bucket, prefix, page)
 	if err != nil {
 		return err
+	}
+
+	// URL-escape object keys and common prefixes if requested
+	if r.FormValue("encoding-type") == "url" {
+		for i := range objects.Contents {
+			objects.Contents[i].Key = urlEscape(objects.Contents[i].Key)
+		}
+		for i := range objects.CommonPrefixes {
+			objects.CommonPrefixes[i].Prefix = urlEscape(objects.CommonPrefixes[i].Prefix)
+		}
 	}
 
 	// prepare result

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -350,6 +350,8 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 	page, err := listObjectsPageFromQuery(q)
 	if err != nil {
 		return err
+	} else if prefix.Delimiter != "" && prefix.Delimiter != "/" {
+		return s3errs.ErrNotImplemented // only "/" delimiter is supported
 	}
 
 	// list objects

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -354,6 +354,11 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 		return s3errs.ErrNotImplemented // only "/" delimiter is supported
 	}
 
+	// don't allow unordered listing with delimiter
+	if _, unordered := q["allow-unordered"]; unordered && prefix.Delimiter != "" {
+		return s3errs.ErrInvalidArgument
+	}
+
 	// list objects
 	objects, err := s.backend.ListObjects(r.Context(), accessKeyID, bucket, prefix, page)
 	if err != nil {
@@ -394,7 +399,7 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 	}
 
 	// if fetch-owner is not set, redact owner information
-	if fo, set := r.Form["fetch-owner"]; !set || fo[0] == "false" {
+	if fo, set := q["fetch-owner"]; !set || fo[0] == "false" {
 		for _, v := range result.Contents {
 			v.Owner = nil
 		}

--- a/s3/urlescape.go
+++ b/s3/urlescape.go
@@ -42,16 +42,6 @@ func urlEscape(s string) string {
 		t = make([]byte, required)
 	}
 
-	if hexCount == 0 {
-		copy(t, s)
-		for i := 0; i < len(s); i++ {
-			if s[i] == ' ' {
-				t[i] = '+'
-			}
-		}
-		return string(t)
-	}
-
 	const upperhex = "0123456789ABCDEF"
 
 	j := 0

--- a/s3/urlescape.go
+++ b/s3/urlescape.go
@@ -1,0 +1,71 @@
+package s3
+
+// shouldEscape reports whether the byte should be escaped by urlEscape. It's
+// similar to net/url.shouldEscape but does not escape '*' and '/'.
+func shouldEscape(c byte) bool {
+	// unreserved alphanumeric characters
+	if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' {
+		return false
+	}
+
+	switch c {
+	case '-', '_', '.': // unreserved mark characters
+		return false
+	case '/', '*': // similar to escaping in URL path segment
+		return false
+	}
+	return true
+}
+
+// urlEscape follows the same rules as net/url.QueryEscape, but it does not
+// escape '*'.
+func urlEscape(s string) string {
+	hexCount := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			hexCount++
+		}
+	}
+
+	if hexCount == 0 {
+		return s
+	}
+
+	var buf [64]byte
+	var t []byte
+
+	required := len(s) + 2*hexCount
+	if required <= len(buf) {
+		t = buf[:required]
+	} else {
+		t = make([]byte, required)
+	}
+
+	if hexCount == 0 {
+		copy(t, s)
+		for i := 0; i < len(s); i++ {
+			if s[i] == ' ' {
+				t[i] = '+'
+			}
+		}
+		return string(t)
+	}
+
+	const upperhex = "0123456789ABCDEF"
+
+	j := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case shouldEscape(c):
+			t[j] = '%'
+			t[j+1] = upperhex[c>>4]
+			t[j+2] = upperhex[c&15]
+			j += 3
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}

--- a/testutils/backend.go
+++ b/testutils/backend.go
@@ -205,16 +205,8 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 		return strings.Compare(a.name, b.name)
 	})
 
-	// apply marker
-	if page.Marker != nil {
-		for len(objects) > 0 && strings.Compare(*page.Marker, objects[0].name) >= 0 {
-			objects = objects[1:]
-		}
-	}
+	result := s3.NewObjectsListResult(page.MaxKeys)
 
-	result := s3.NewObjectsListResult()
-
-	var cntr int64
 	var lastMatchedPart string
 
 	for _, obj := range objects {
@@ -223,33 +215,32 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 		case match == nil:
 			continue
 		case match.CommonPrefix:
+			if page.Marker != nil && strings.Compare(*page.Marker, match.MatchedPart) >= 0 {
+				continue
+			}
 			if match.MatchedPart == lastMatchedPart {
 				continue // should not count towards keys
 			}
-			if cntr < page.MaxKeys {
-				result.AddPrefix(match.MatchedPart)
-			}
+			result.AddPrefix(match.MatchedPart)
 			lastMatchedPart = match.MatchedPart
 		default:
-			if cntr < page.MaxKeys {
-				result.Add(&s3.Content{
-					Key:          obj.name,
-					LastModified: s3.NewContentTime(obj.lastModified),
-					ETag:         s3.FormatETag(obj.contentMD5[:]),
-					Size:         int64(len(obj.data)),
-				})
+			if page.Marker != nil && strings.Compare(*page.Marker, obj.name) >= 0 {
+				continue
 			}
+			result.Add(&s3.Content{
+				Key:          obj.name,
+				LastModified: s3.NewContentTime(obj.lastModified),
+				ETag:         s3.FormatETag(obj.contentMD5[:]),
+				Size:         int64(len(obj.data)),
+			})
 		}
 
-		cntr++
-		if page.MaxKeys > 0 {
-			if cntr == page.MaxKeys {
-				result.NextMarker = obj.name
-			} else if cntr > page.MaxKeys {
-				result.IsTruncated = true
-				break
-			}
+		if result.IsTruncated {
+			break
 		}
+	}
+	if !result.IsTruncated {
+		result.NextMarker = ""
 	}
 
 	return result, nil

--- a/testutils/backend.go
+++ b/testutils/backend.go
@@ -206,6 +206,9 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 	})
 
 	result := s3.NewObjectsListResult(page.MaxKeys)
+	if page.MaxKeys == 0 {
+		return result, nil
+	}
 
 	var lastMatchedPart string
 

--- a/testutils/backend.go
+++ b/testutils/backend.go
@@ -234,7 +234,10 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 				Key:          obj.name,
 				LastModified: s3.NewContentTime(obj.lastModified),
 				ETag:         s3.FormatETag(obj.contentMD5[:]),
-				Size:         int64(len(obj.data)),
+				Owner: &s3.UserInfo{
+					ID: bkt.owner,
+				},
+				Size: int64(len(obj.data)),
 			})
 		}
 


### PR DESCRIPTION
This PR enables the subset of `ListObjectsV2` tests in `test_s3.py` of the compatibility test suite and fixes issues that caused tests to fail.