### PR TITLE
Enable multipart tests

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -84,7 +84,8 @@ jobs:
           S3_USE_SIGV4: "True" # We only support v4 signatures
         run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
-            -m "(copy or list_objects_v2) and not multipart and not s3d_not_implemented and not s3d_not_supported"
+            -k "copy or list_objects_v2 or multipart" \
+            -m "not s3d_not_implemented and not s3d_not_supported and not bucket_logging"
 
       # NOTE: The following tests are currently disabled
       #

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -84,8 +84,7 @@ jobs:
           S3_USE_SIGV4: "True" # We only support v4 signatures
         run: |
           tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
-            -k "copy or list_objects_v2 or multipart" \
-            -m "not s3d_not_implemented and not s3d_not_supported and not bucket_logging"
+            -m "(copy or list_objects_v2 or multipart) and not s3d_not_implemented and not s3d_not_supported and not bucket_logging"
 
       # NOTE: The following tests are currently disabled
       #


### PR DESCRIPTION
This PR enables multipart tests

```
➜  siafoundation tox run --skip-pkg-install -c ./s3-tests -- s3tests/functional/test_s3.py \
            -k "copy or list_objects_v2 or multipart" \
            -m "not s3d_not_implemented and not s3d_not_supported and not bucket_logging"
            

s3tests/functional/test_s3.py .............................................................................                                                                                                                                                                                                             [100%]

==== 77 passed, 671 deselected in 8.06s ====
  py: OK (8.28=setup[0.03]+cmd[8.25] seconds)
  congratulations :) (8.29 seconds)
  ```