### PR TITLE
Update AbortMultipartUpload

### DIFF
--- a/internal/testutil/backend.go
+++ b/internal/testutil/backend.go
@@ -49,7 +49,6 @@ type (
 
 	object struct {
 		name         string
-		etag         string
 		data         []byte
 		lastModified time.Time
 		metadata     map[string]string
@@ -678,7 +677,6 @@ func (b *MemoryBackend) CompleteMultipartUpload(_ context.Context, accessKeyID, 
 	}
 	bkt.objects[key] = &object{
 		name:         key,
-		etag:         etag,
 		data:         objData,
 		lastModified: time.Now(),
 		metadata:     upload.metadata,

--- a/internal/testutil/backend.go
+++ b/internal/testutil/backend.go
@@ -49,6 +49,7 @@ type (
 
 	object struct {
 		name         string
+		etag         string
 		data         []byte
 		lastModified time.Time
 		metadata     map[string]string
@@ -56,11 +57,13 @@ type (
 	}
 
 	multipartUpload struct {
-		bucket    string
-		key       string
-		metadata  map[string]string
-		parts     map[int]*multipartPart
+		bucket   string
+		key      string
+		metadata map[string]string
+		parts    map[int]*multipartPart
+
 		createdAt time.Time
+		abortedAt time.Time
 	}
 
 	multipartPart struct {
@@ -355,6 +358,13 @@ func (b *MemoryBackend) CreateMultipartUpload(_ context.Context, accessKeyID, bu
 		createdAt: time.Now(),
 	}
 
+	// clean up old aborted uploads
+	for uploadID, upload := range b.multipartUploads {
+		if !upload.abortedAt.IsZero() && time.Since(upload.abortedAt) > time.Hour {
+			delete(b.multipartUploads, uploadID)
+		}
+	}
+
 	return &s3.CreateMultipartUploadResult{
 		UploadID: uploadID,
 	}, nil
@@ -378,6 +388,9 @@ func (b *MemoryBackend) ListMultipartUploads(_ context.Context, accessKeyID, buc
 
 	var entries []entry
 	for id, upload := range b.multipartUploads {
+		if !upload.abortedAt.IsZero() {
+			continue
+		}
 		if upload.bucket != bucket {
 			continue
 		}
@@ -454,6 +467,7 @@ func (b *MemoryBackend) ListMultipartUploads(_ context.Context, accessKeyID, buc
 // AbortMultipartUpload aborts an in-progress multipart upload and discards
 // any uploaded parts.
 func (b *MemoryBackend) AbortMultipartUpload(_ context.Context, accessKeyID, bucket, key, uploadID string) error {
+	// validate bucket
 	bkt, exists := b.buckets[bucket]
 	if !exists {
 		return s3errs.ErrNoSuchBucket
@@ -461,19 +475,25 @@ func (b *MemoryBackend) AbortMultipartUpload(_ context.Context, accessKeyID, buc
 	if bkt.owner != b.accessKeys[accessKeyID].owner {
 		return s3errs.ErrAccessDenied
 	}
+
+	// validate uploadID
 	upload, exists := b.multipartUploads[uploadID]
 	if !exists {
 		return s3errs.ErrNoSuchUpload
-	}
-	if upload.bucket != bucket || upload.key != key {
+	} else if upload.bucket != bucket || upload.key != key {
 		return s3errs.ErrNoSuchUpload
 	}
-	delete(b.multipartUploads, uploadID)
+
+	// free resources and mark as aborted
+	upload.parts = make(map[int]*multipartPart)
+	upload.abortedAt = time.Now()
+
 	return nil
 }
 
 // UploadPart uploads a single part for a multipart upload.
 func (b *MemoryBackend) UploadPart(_ context.Context, accessKeyID, bucket, key, uploadID string, r io.Reader, opts s3.UploadPartOptions) (*s3.UploadPartResult, error) {
+	// validate bucket
 	bkt, exists := b.buckets[bucket]
 	if !exists {
 		return nil, s3errs.ErrNoSuchBucket
@@ -481,11 +501,17 @@ func (b *MemoryBackend) UploadPart(_ context.Context, accessKeyID, bucket, key, 
 	if bkt.owner != b.accessKeys[accessKeyID].owner {
 		return nil, s3errs.ErrAccessDenied
 	}
+
+	// validate uploadID
 	upload, exists := b.multipartUploads[uploadID]
 	if !exists {
 		return nil, s3errs.ErrNoSuchUpload
+	} else if upload.bucket != bucket || upload.key != key {
+		return nil, s3errs.ErrNoSuchUpload
 	}
-	if upload.bucket != bucket || upload.key != key {
+
+	// validate upload state
+	if !upload.abortedAt.IsZero() {
 		return nil, s3errs.ErrNoSuchUpload
 	}
 
@@ -519,6 +545,7 @@ func (b *MemoryBackend) UploadPart(_ context.Context, accessKeyID, bucket, key, 
 
 // ListParts lists uploaded parts for an in-progress multipart upload.
 func (b *MemoryBackend) ListParts(_ context.Context, accessKeyID, bucket, key, uploadID string, page s3.ListPartsPage) (*s3.ListPartsResult, error) {
+	// validate bucket
 	bkt, exists := b.buckets[bucket]
 	if !exists {
 		return nil, s3errs.ErrNoSuchBucket
@@ -526,11 +553,12 @@ func (b *MemoryBackend) ListParts(_ context.Context, accessKeyID, bucket, key, u
 	if bkt.owner != b.accessKeys[accessKeyID].owner {
 		return nil, s3errs.ErrAccessDenied
 	}
+
+	// validate uploadID
 	upload, exists := b.multipartUploads[uploadID]
 	if !exists {
 		return nil, s3errs.ErrNoSuchUpload
-	}
-	if upload.bucket != bucket || upload.key != key {
+	} else if upload.bucket != bucket || upload.key != key {
 		return nil, s3errs.ErrNoSuchUpload
 	}
 
@@ -579,6 +607,7 @@ func (b *MemoryBackend) ListParts(_ context.Context, accessKeyID, bucket, key, u
 
 // CompleteMultipartUpload assembles the uploaded parts into the final object.
 func (b *MemoryBackend) CompleteMultipartUpload(_ context.Context, accessKeyID, bucket, key, uploadID string, parts []s3.CompletedPart) (*s3.CompleteMultipartUploadResult, error) {
+	// validate bucket
 	bkt, exists := b.buckets[bucket]
 	if !exists {
 		return nil, s3errs.ErrNoSuchBucket
@@ -586,14 +615,18 @@ func (b *MemoryBackend) CompleteMultipartUpload(_ context.Context, accessKeyID, 
 	if bkt.owner != b.accessKeys[accessKeyID].owner {
 		return nil, s3errs.ErrAccessDenied
 	}
+
+	// validate uploadID
 	upload, exists := b.multipartUploads[uploadID]
 	if !exists {
 		return nil, s3errs.ErrNoSuchUpload
-	}
-	if upload.bucket != bucket || upload.key != key {
+	} else if upload.bucket != bucket || upload.key != key {
+		return nil, s3errs.ErrNoSuchUpload
+	} else if !upload.abortedAt.IsZero() {
 		return nil, s3errs.ErrNoSuchUpload
 	}
 
+	// validate parts
 	if len(parts) == 0 {
 		return nil, s3errs.ErrInvalidRequest
 	}
@@ -645,13 +678,14 @@ func (b *MemoryBackend) CompleteMultipartUpload(_ context.Context, accessKeyID, 
 	}
 	bkt.objects[key] = &object{
 		name:         key,
+		etag:         etag,
 		data:         objData,
 		lastModified: time.Now(),
 		metadata:     upload.metadata,
 		contentMD5:   objMD5,
 	}
-	delete(b.multipartUploads, uploadID)
 
+	delete(b.multipartUploads, uploadID)
 	return &s3.CompleteMultipartUploadResult{
 		ETag:       etag,
 		ContentMD5: objMD5,

--- a/s3/multipart_test.go
+++ b/s3/multipart_test.go
@@ -214,14 +214,6 @@ func TestCompleteMultipartUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// assert completeMultipartUpload is idempotent
-	completed, err = s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, uploadID, parts)
-	if err != nil {
-		t.Fatal(err)
-	} else if completed.ETag == nil {
-		t.Fatal("expected ETag in completion response")
-	}
-
 	// assert final ETag is correct
 	p1MD5 := md5.Sum(p1Data)
 	p2MD5 := md5.Sum(p2Data)

--- a/s3/multipart_test.go
+++ b/s3/multipart_test.go
@@ -526,4 +526,15 @@ func TestListParts(t *testing.T) {
 	} else if nextPage.Parts[0].PartNumber == nil || *nextPage.Parts[0].PartNumber != 3 {
 		t.Fatalf("expected final part number 3, got %v", nextPage.Parts[0].PartNumber)
 	}
+
+	// assert we can list parts after aborting the upload
+	if err := s3Tester.AbortMultipartUpload(t.Context(), bucket, object, uploadID); err != nil {
+		t.Fatal(err)
+	}
+	aborted, err := s3Tester.ListParts(t.Context(), bucket, object, uploadID, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(aborted.Parts) != 0 {
+		t.Fatalf("expected 0 parts, got %d", len(aborted.Parts))
+	}
 }

--- a/s3/multipart_test.go
+++ b/s3/multipart_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -109,9 +110,10 @@ func TestAbortMultipartUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// assert [s3errs.ErrNoSuchUpload] is returned if the upload was already aborted
-	err = s3Tester.AbortMultipartUpload(t.Context(), bucket, object, uploadID)
-	testutil.AssertS3Error(t, s3errs.ErrNoSuchUpload, err)
+	// assert we can call abort again without error
+	if err := s3Tester.AbortMultipartUpload(t.Context(), bucket, object, uploadID); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestUploadPart(t *testing.T) {
@@ -155,8 +157,16 @@ func TestUploadPart(t *testing.T) {
 		t.Fatalf("expected ETag %x, got %q", expectedMD5, *part.ETag)
 	}
 
+	// assert [s3errs.ErrNoSuchUpload] is returned for aborted upload
+	if err := s3Tester.AbortMultipartUpload(t.Context(), bucket, object, uploadID); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s3Tester.UploadPart(t.Context(), bucket, object, uploadID, 1, data)
+	testutil.AssertS3Error(t, s3errs.ErrNoSuchUpload, err)
+
 	// assert [s3errs.ErrInvalidArgument] is returned for invalid part number
-	_, err = s3Tester.UploadPart(t.Context(), bucket, object, *res.UploadId, 0, data)
+	uploadID, _ = newTestMultipartUpload(t, s3Tester, bucket, object, nil)
+	_, err = s3Tester.UploadPart(t.Context(), bucket, object, uploadID, 0, data)
 	testutil.AssertS3Error(t, s3errs.ErrInvalidArgument, err)
 
 	// assert [s3errs.ErrNoSuchUpload] is returned for invalid upload id
@@ -202,6 +212,12 @@ func TestCompleteMultipartUpload(t *testing.T) {
 	completed, err := s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, uploadID, parts)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// assert completeMultipartUpload is idempotent
+	completed, err = s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, uploadID, parts)
+	if err != nil {
+		t.Fatal(err)
 	} else if completed.ETag == nil {
 		t.Fatal("expected ETag in completion response")
 	}
@@ -234,8 +250,20 @@ func TestCompleteMultipartUpload(t *testing.T) {
 		t.Fatalf("unexpected object data")
 	}
 
+	// assert [s3errs.ErrNoSuchUpload] for already completed upload
+	_, err = s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, uploadID, parts)
+	testutil.AssertS3Error(t, s3errs.ErrNoSuchUpload, err)
+
 	// assert [s3errs.ErrNoSuchUpload] is returned for invalid upload id
 	_, err = s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, "nonexistent-upload", parts)
+	testutil.AssertS3Error(t, s3errs.ErrNoSuchUpload, err)
+
+	// assert [s3errs.ErrNoSuchUpload] is returned for aborted upload
+	uploadID, _ = newTestMultipartUpload(t, s3Tester, bucket, object, [][]byte{p1Data, p2Data})
+	if err := s3Tester.AbortMultipartUpload(t.Context(), bucket, object, uploadID); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, uploadID, parts)
 	testutil.AssertS3Error(t, s3errs.ErrNoSuchUpload, err)
 
 	// assert [s3errs.ErrNoSuchBucket] is returned for nonexistent bucket
@@ -291,10 +319,7 @@ func TestListMultipartUploads(t *testing.T) {
 	}
 
 	// create multipart upload
-	mp1, err := s3Tester.CreateMultipartUpload(t.Context(), bucket, "multipart-upload-1", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	uploadID1, parts1 := newTestMultipartUpload(t, s3Tester, bucket, "multipart-upload-1", [][]byte{[]byte("part1")})
 
 	// assert the upload shows up in the listing
 	res, err = s3Tester.ListMultipartUploads(t.Context(), bucket, nil)
@@ -302,15 +327,12 @@ func TestListMultipartUploads(t *testing.T) {
 		t.Fatal(err)
 	} else if len(res.Uploads) != 1 {
 		t.Fatalf("expected 1 upload, got %d", len(res.Uploads))
-	} else if *res.Uploads[0].UploadId != *mp1.UploadId {
-		t.Fatalf("expected upload ID %q, got %q", *mp1.UploadId, *res.Uploads[0].UploadId)
+	} else if *res.Uploads[0].UploadId != uploadID1 {
+		t.Fatalf("expected upload ID %q, got %q", uploadID1, *res.Uploads[0].UploadId)
 	}
 
 	// create another multipart upload
-	mp2, err := s3Tester.CreateMultipartUpload(t.Context(), bucket, "multipart-upload-2", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	uploadID2, parts2 := newTestMultipartUpload(t, s3Tester, bucket, "multipart-upload-2", [][]byte{[]byte("part1")})
 
 	// assert both uploads show up in the listing
 	res, err = s3Tester.ListMultipartUploads(t.Context(), bucket, nil)
@@ -330,12 +352,12 @@ func TestListMultipartUploads(t *testing.T) {
 		t.Fatal("expected truncated response")
 	} else if aws.ToString(limited.NextKeyMarker) != "multipart-upload-1" {
 		t.Fatal("expected next key marker in response")
-	} else if aws.ToString(limited.NextUploadIdMarker) != *mp1.UploadId {
+	} else if aws.ToString(limited.NextUploadIdMarker) != uploadID1 {
 		t.Fatal("expected next upload id marker in response")
 	} else if len(limited.Uploads) != 1 {
 		t.Fatalf("expected 1 upload, got %d", len(limited.Uploads))
-	} else if *limited.Uploads[0].UploadId != *mp1.UploadId {
-		t.Fatalf("expected upload ID %q, got %q", *mp1.UploadId, *limited.Uploads[0].UploadId)
+	} else if *limited.Uploads[0].UploadId != uploadID1 {
+		t.Fatalf("expected upload ID %q, got %q", uploadID1, *limited.Uploads[0].UploadId)
 	}
 
 	paginated, err := s3Tester.ListMultipartUploads(t.Context(), bucket, &service.ListMultipartUploadsInput{
@@ -346,17 +368,14 @@ func TestListMultipartUploads(t *testing.T) {
 		t.Fatal(err)
 	} else if len(paginated.Uploads) != 1 {
 		t.Fatalf("expected 1 upload, got %d", len(paginated.Uploads))
-	} else if *paginated.Uploads[0].UploadId != *mp2.UploadId {
-		t.Fatalf("expected upload ID %q, got %q", *mp2.UploadId, *paginated.Uploads[0].UploadId)
+	} else if *paginated.Uploads[0].UploadId != uploadID2 {
+		t.Fatalf("expected upload ID %q, got %q", uploadID2, *paginated.Uploads[0].UploadId)
 	} else if aws.ToBool(paginated.IsTruncated) {
 		t.Fatal("did not expect truncated response")
 	}
 
 	// create another multipart upload
-	_, err = s3Tester.CreateMultipartUpload(t.Context(), bucket, "non-prefixed-upload-3", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, _ = newTestMultipartUpload(t, s3Tester, bucket, "non-prefixed-upload-3", [][]byte{[]byte("part1")})
 	prefixed, err := s3Tester.ListMultipartUploads(t.Context(), bucket, &service.ListMultipartUploadsInput{
 		Prefix: aws.String("multipart-"),
 	})
@@ -369,6 +388,23 @@ func TestListMultipartUploads(t *testing.T) {
 		if !strings.HasPrefix(aws.ToString(upload.Key), "multipart-") {
 			t.Fatalf("unexpected key in prefix listing: %v", upload.Key)
 		}
+	}
+
+	// complete the first two uploads
+	_, err1 := s3Tester.CompleteMultipartUpload(t.Context(), bucket, "multipart-upload-1", uploadID1, parts1)
+	_, err2 := s3Tester.CompleteMultipartUpload(t.Context(), bucket, "multipart-upload-2", uploadID2, parts2)
+	if err := errors.Join(err1, err2); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert only the remaining upload shows up in the listing
+	res, err = s3Tester.ListMultipartUploads(t.Context(), bucket, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(res.Uploads) != 1 {
+		t.Fatalf("expected 1 upload, got %d", len(res.Uploads))
+	} else if *res.Uploads[0].Key != "non-prefixed-upload-3" {
+		t.Fatalf("expected remaining upload to be 'non-prefixed-upload-3', got %q", *res.Uploads[0].Key)
 	}
 
 	// assert [s3errs.ErrAccessDenied] is returned for unauthorized access


### PR DESCRIPTION
I was under the impression that `CompleteMultipartUpload` should be idempotent, but now believe this should not be the case. This contradicts the s3-tests though which has consecutive calls to `CompleteMultipartUpload` that fail with our current implementation. The docs are very clear though, `CompleteMultipartUpload` should return an error if the upload has been aborted or completed.

I do believe we have to update the behaviour of `AbortMultipartUpload`, which is not idempotent but should not fail if you call it twice with the same upload ID. This is because abort frees up the parts resources, and certain parts might still be uploading after the initial call to abort. This PR changes that and adds a small cleanup step to our memory backend to prevent memory leaking.

> As a result, it might be necessary to abort a given multipart upload multiple times in order to completely free all storage consumed by all parts.

straight from the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html)


In the [glacier docs](https://docs.aws.amazon.com/cli/latest/reference/glacier/complete-multipart-upload.html) for `CompleteMultipartUpload` it clearly states that it should be idempotent. I propose to keep this implementation and update the s3-tests to remove that consecutive call in the python test suite.