### PR TITLE
Add Get|HeadObjectPart

### DIFF
--- a/internal/testutil/backend.go
+++ b/internal/testutil/backend.go
@@ -53,6 +53,13 @@ type (
 		lastModified time.Time
 		metadata     map[string]string
 		contentMD5   [16]byte
+		parts        map[int]objectMultipartPart
+	}
+
+	objectMultipartPart struct {
+		offset     int64
+		length     int64
+		contentMD5 [16]byte
 	}
 
 	multipartUpload struct {
@@ -129,6 +136,7 @@ func (b *MemoryBackend) CopyObject(ctx context.Context, accessKeyID, srcBucket, 
 		lastModified: time.Now(),
 		metadata:     meta,
 		contentMD5:   srcObjct.contentMD5,
+		parts:        srcObjct.parts,
 	}
 	b.buckets[dstBucket].objects[dstObject] = dstObjct
 	return &s3.CopyObjectResult{
@@ -208,8 +216,8 @@ func (b *MemoryBackend) DeleteObjects(ctx context.Context, accessKeyID, bucket s
 }
 
 // GetObject retrieves an object from the specified bucket.
-func (b *MemoryBackend) GetObject(ctx context.Context, accessKeyID *string, bucket, object string, requestedRange *s3.ObjectRangeRequest) (*s3.Object, error) {
-	return b.headOrGetObject(ctx, accessKeyID, bucket, object, requestedRange, false)
+func (b *MemoryBackend) GetObject(ctx context.Context, accessKeyID *string, bucket, object string, requestedRange *s3.ObjectRangeRequest, partNumber *int32) (*s3.Object, error) {
+	return b.headOrGetObject(ctx, accessKeyID, bucket, object, requestedRange, partNumber, false)
 }
 
 // HeadBucket checks if the specified bucket exists and is owned by the user.
@@ -225,8 +233,8 @@ func (b *MemoryBackend) HeadBucket(ctx context.Context, accessKeyID, bucket stri
 
 // HeadObject retrieves metadata about the specified object without returning
 // the object's data.
-func (b *MemoryBackend) HeadObject(ctx context.Context, accessKeyID *string, bucket, object string, requestedRange *s3.ObjectRangeRequest) (*s3.Object, error) {
-	return b.headOrGetObject(ctx, accessKeyID, bucket, object, requestedRange, true)
+func (b *MemoryBackend) HeadObject(ctx context.Context, accessKeyID *string, bucket, object string, requestedRange *s3.ObjectRangeRequest, partNumber *int32) (*s3.Object, error) {
+	return b.headOrGetObject(ctx, accessKeyID, bucket, object, requestedRange, partNumber, true)
 }
 
 // ListObjects lists objects in the specified bucket that match the given prefix
@@ -327,6 +335,7 @@ func (b *MemoryBackend) PutObject(_ context.Context, accessKeyID, bucket, obj st
 		contentMD5:   contentMD5,
 		lastModified: time.Now(),
 		metadata:     opts.Meta,
+		parts:        make(map[int]objectMultipartPart),
 	}
 	return &s3.PutObjectResult{
 		ContentMD5: contentMD5,
@@ -560,7 +569,7 @@ func (b *MemoryBackend) ListParts(_ context.Context, accessKeyID, bucket, key, u
 			result.IsTruncated = true
 			if len(result.Parts) > 0 {
 				last := result.Parts[len(result.Parts)-1].PartNumber
-				result.NextPartNumberMarker = strconv.Itoa(last)
+				result.NextPartNumberMarker = strconv.Itoa(int(last))
 			}
 			break
 		}
@@ -601,6 +610,7 @@ func (b *MemoryBackend) CompleteMultipartUpload(_ context.Context, accessKeyID, 
 	// validate parts
 	var prev, totalSize int
 	objHash := make([]byte, 0, len(parts)*ETagSize)
+	objParts := make(map[int]objectMultipartPart, len(parts))
 	for i, completed := range parts {
 		if i > 0 && completed.PartNumber <= prev {
 			return nil, s3errs.ErrInvalidPartOrder
@@ -619,8 +629,14 @@ func (b *MemoryBackend) CompleteMultipartUpload(_ context.Context, accessKeyID, 
 			return nil, s3errs.ErrEntityTooSmall
 		}
 
-		totalSize += len(part.data)
 		objHash = append(objHash, part.contentMD5[:]...)
+		objParts[completed.PartNumber] = objectMultipartPart{
+			offset:     int64(totalSize),
+			length:     int64(len(part.data)),
+			contentMD5: part.contentMD5,
+		}
+
+		totalSize += len(part.data)
 	}
 
 	// collect object data
@@ -649,6 +665,7 @@ func (b *MemoryBackend) CompleteMultipartUpload(_ context.Context, accessKeyID, 
 		lastModified: time.Now(),
 		metadata:     upload.metadata,
 		contentMD5:   objMD5,
+		parts:        objParts,
 	}
 	delete(b.multipartUploads, uploadID)
 
@@ -681,7 +698,7 @@ func (b *MemoryBackend) LoadSecret(ctx context.Context, accessKeyID string) (aut
 	return nil, s3errs.ErrInvalidAccessKeyId
 }
 
-func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, bucket, object string, requestedRange *s3.ObjectRangeRequest, head bool) (*s3.Object, error) {
+func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, bucket, object string, requestedRange *s3.ObjectRangeRequest, partNumber *int32, head bool) (*s3.Object, error) {
 	bkt, exists := b.buckets[bucket]
 	if !exists {
 		return nil, s3errs.ErrNoSuchBucket
@@ -697,7 +714,31 @@ func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, 
 	rnge, err := requestedRange.Range(size)
 	if err != nil {
 		return nil, err
+	} else if rnge != nil {
+		partNumber = nil // ignore part number when a range is requested
 	}
+
+	var contentMD5 [16]byte
+	if partNumber != nil {
+		partInfo, exists := obj.parts[int(*partNumber)]
+		if !exists {
+			return nil, s3errs.ErrInvalidPart
+		}
+		rnge = &s3.ObjectRange{
+			Start:  partInfo.offset,
+			Length: partInfo.length,
+		}
+		contentMD5 = partInfo.contentMD5
+	} else {
+		contentMD5 = obj.contentMD5
+	}
+
+	var partCount *int32
+	if partNumber != nil {
+		pc := int32(len(obj.parts))
+		partCount = &pc
+	}
+
 	var body io.ReadCloser
 	if !head {
 		if rnge == nil {
@@ -708,10 +749,11 @@ func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, 
 	}
 	return &s3.Object{
 		Body:         body,
-		ContentMD5:   obj.contentMD5,
+		ContentMD5:   contentMD5,
 		LastModified: obj.lastModified,
 		Metadata:     obj.metadata,
 		Range:        rnge,
 		Size:         size,
+		PartsCount:   partCount,
 	}, nil
 }

--- a/internal/testutil/backend.go
+++ b/internal/testutil/backend.go
@@ -718,25 +718,31 @@ func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, 
 		partNumber = nil // ignore part number when a range is requested
 	}
 
+	var partCount *int32
 	var contentMD5 [16]byte
 	if partNumber != nil {
-		partInfo, exists := obj.parts[int(*partNumber)]
-		if !exists {
-			return nil, s3errs.ErrInvalidPart
+		if len(obj.parts) == 0 {
+			if *partNumber != 1 {
+				return nil, s3errs.ErrInvalidPart
+			}
+			pc := int32(1)
+			partCount = &pc
+			contentMD5 = obj.contentMD5
+		} else {
+			partInfo, exists := obj.parts[int(*partNumber)]
+			if !exists {
+				return nil, s3errs.ErrInvalidPart
+			}
+			rnge = &s3.ObjectRange{
+				Start:  partInfo.offset,
+				Length: partInfo.length,
+			}
+			contentMD5 = partInfo.contentMD5
+			pc := int32(len(obj.parts))
+			partCount = &pc
 		}
-		rnge = &s3.ObjectRange{
-			Start:  partInfo.offset,
-			Length: partInfo.length,
-		}
-		contentMD5 = partInfo.contentMD5
 	} else {
 		contentMD5 = obj.contentMD5
-	}
-
-	var partCount *int32
-	if partNumber != nil {
-		pc := int32(len(obj.parts))
-		partCount = &pc
 	}
 
 	var body io.ReadCloser

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -175,6 +175,45 @@ func (t *S3Tester) GetObject(ctx context.Context, bucket, object string, rnge *s
 		Metadata:     resp.Metadata,
 		Range:        objRange,
 		Size:         size,
+		PartsCount:   resp.PartsCount,
+	}, nil
+}
+
+// GetObjectPart is a convenience wrapper around the AWS SDK's GetObject API that
+// allows specifying a part to download.
+func (t *S3Tester) GetObjectPart(ctx context.Context, bucket, object string, partNumber int32) (*s3.Object, error) {
+	resp, err := t.client.GetObject(ctx, &service.GetObjectInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String(object),
+		PartNumber: aws.Int32(partNumber),
+	})
+	if err != nil {
+		return nil, err
+	}
+	etag := strings.Trim(*resp.ETag, `"`)
+	var contentMD5 [16]byte
+	_, err = hex.Decode(contentMD5[:], []byte(etag))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
+	}
+	var objRange *s3.ObjectRange
+	var size int64
+	if resp.ContentRange != nil {
+		objRange, size, err = parseRange(*resp.ContentRange)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		size = *resp.ContentLength
+	}
+	return &s3.Object{
+		Body:         resp.Body,
+		ContentMD5:   contentMD5,
+		LastModified: *resp.LastModified,
+		Metadata:     resp.Metadata,
+		Range:        objRange,
+		Size:         size,
+		PartsCount:   resp.PartsCount,
 	}, nil
 }
 
@@ -218,6 +257,44 @@ func (t *S3Tester) HeadObject(ctx context.Context, bucket, object string, rnge *
 		Metadata:     resp.Metadata,
 		Range:        objRange,
 		Size:         size,
+		PartsCount:   resp.PartsCount,
+	}, nil
+}
+
+// HeadObjectPart is a convenience wrapper around the AWS SDK's HeadObject API
+// that allows specifying a part.
+func (t *S3Tester) HeadObjectPart(ctx context.Context, bucket, object string, partNumber int32) (*s3.Object, error) {
+	resp, err := t.client.HeadObject(ctx, &service.HeadObjectInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String(object),
+		PartNumber: aws.Int32(partNumber),
+	})
+	if err != nil {
+		return nil, err
+	}
+	etag := strings.Trim(*resp.ETag, `"`)
+	var contentMD5 [16]byte
+	_, err = hex.Decode(contentMD5[:], []byte(etag))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
+	}
+	var objRange *s3.ObjectRange
+	var size int64
+	if resp.ContentRange != nil {
+		objRange, size, err = parseRange(*resp.ContentRange)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		size = *resp.ContentLength
+	}
+	return &s3.Object{
+		ContentMD5:   contentMD5,
+		LastModified: *resp.LastModified,
+		Metadata:     resp.Metadata,
+		Range:        objRange,
+		Size:         size,
+		PartsCount:   resp.PartsCount,
 	}, nil
 }
 

--- a/s3/multipart.go
+++ b/s3/multipart.go
@@ -123,7 +123,7 @@ func (s *s3) routeMultipartUpload(w http.ResponseWriter, r *http.Request, access
 
 	switch r.Method {
 	case http.MethodPut:
-		return s.addUploadPart(w, r, validatedKey, bucket, object, uploadID, r.URL.Query().Get("partNumber"))
+		return s.addUploadPart(w, r, validatedKey, bucket, object, uploadID)
 	case http.MethodGet:
 		return s.listUploadParts(w, r, validatedKey, bucket, object, uploadID)
 	case http.MethodPost:
@@ -258,18 +258,21 @@ func (s *s3) listMultipartUploads(w http.ResponseWriter, r *http.Request, access
 	return writeXMLResponse(w, resp)
 }
 
-func (s *s3) addUploadPart(w http.ResponseWriter, r *http.Request, accessKeyID, bucket, object, uploadID, partNumberStr string) error {
+func (s *s3) addUploadPart(w http.ResponseWriter, r *http.Request, accessKeyID, bucket, object, uploadID string) error {
 	log := s.logger.With(
 		zap.String("bucket", bucket),
 		zap.String("object", object),
 		zap.String("uploadID", uploadID),
-		zap.String("partNumber", partNumberStr),
+		zap.String("partNumber", r.URL.Query().Get("partNumber")),
 	)
 	log.Debug("upload multipart part")
 
-	partNumber, err := parsePartNumber(partNumberStr)
+	// parse part number
+	partNumber, err := parsePartNumber(r.URL.Query().Get("partNumber"))
 	if err != nil {
 		return err
+	} else if partNumber == nil {
+		return s3errs.ErrInvalidRequest
 	}
 
 	// content length is mandatory
@@ -295,7 +298,7 @@ func (s *s3) addUploadPart(w http.ResponseWriter, r *http.Request, accessKeyID, 
 	}
 
 	res, err := s.backend.UploadPart(r.Context(), accessKeyID, bucket, object, uploadID, r.Body, UploadPartOptions{
-		PartNumber:    partNumber,
+		PartNumber:    int(*partNumber),
 		ContentLength: r.ContentLength,
 		ContentMD5:    contentMD5,
 		ContentSHA256: contentSHA256,
@@ -417,20 +420,6 @@ func (s *s3) completeMultipartUpload(w http.ResponseWriter, r *http.Request, acc
 	})
 }
 
-func parsePartNumber(partStr string) (int, error) {
-	if partStr == "" {
-		return 0, s3errs.ErrInvalidRequest
-	}
-	partNumber, err := strconv.Atoi(partStr)
-	if err != nil {
-		return 0, s3errs.ErrInvalidArgument
-	}
-	if partNumber < 1 || partNumber > MaxUploadPartNumber {
-		return 0, s3errs.ErrInvalidArgument
-	}
-	return partNumber, nil
-}
-
 func parseCompletedParts(parts []CompleteMultipartPartXML) ([]CompletedPart, error) {
 	if len(parts) == 0 {
 		return nil, s3errs.ErrInvalidRequest
@@ -474,6 +463,22 @@ func parseCompletedPartETag(etagStr string) (etag [16]byte, _ error) {
 	}
 	copy(etag[:], decoded)
 	return etag, nil
+}
+
+func parsePartNumber(s string) (*int32, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	partNumber, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, s3errs.ErrInvalidArgument
+	}
+	if partNumber < 1 || partNumber > MaxUploadPartNumber {
+		return nil, s3errs.ErrInvalidArgument
+	}
+	val := int32(partNumber)
+	return &val, nil
 }
 
 // FormatMultipartETag formats the MD5 checksum of concatenated part hashes

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -27,6 +27,10 @@ type Object struct {
 	Metadata     map[string]string
 	Range        *ObjectRange
 	Size         int64
+
+	// PartsCount will be set for objects that are multipart uploads, but only
+	// if a multipart part number is specified.
+	PartsCount *int32
 }
 
 // CopyObjectResult contains information about the result of a CopyObject
@@ -245,15 +249,22 @@ func (s *s3) getObject(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 		zap.String("version", version))
 	log.Debug("get object")
 
+	partNumber, err := parsePartNumber(r.URL.Query().Get("partNumber"))
+	if err != nil {
+		return err
+	}
+
 	rnge, err := parseRangeHeader(r.Header.Get("Range"))
 	if err != nil {
 		return err
+	} else if rnge != nil && partNumber != nil {
+		return s3errs.ErrInvalidRequest // can't combine range and partNumber
 	}
 
 	// retrieve object
 	var obj *Object
 	if version == "" {
-		obj, err = s.backend.GetObject(r.Context(), accessKeyID, bucket, object, rnge)
+		obj, err = s.backend.GetObject(r.Context(), accessKeyID, bucket, object, rnge, partNumber)
 	} else {
 		return s3errs.ErrNotImplemented // versioning not supported
 	}
@@ -282,15 +293,22 @@ func (s *s3) headObject(w http.ResponseWriter, r *http.Request, accessKeyID *str
 		zap.String("version", version))
 	log.Debug("head object")
 
+	partNumber, err := parsePartNumber(r.URL.Query().Get("partNumber"))
+	if err != nil {
+		return err
+	}
+
 	rnge, err := parseRangeHeader(r.Header.Get("Range"))
 	if err != nil {
 		return err
+	} else if rnge != nil && partNumber != nil {
+		return s3errs.ErrInvalidRequest // can't combine range and partNumber
 	}
 
 	// retrieve object metadata
 	var obj *Object
 	if version == "" {
-		obj, err = s.backend.HeadObject(r.Context(), accessKeyID, bucket, object, rnge)
+		obj, err = s.backend.HeadObject(r.Context(), accessKeyID, bucket, object, rnge, partNumber)
 	} else {
 		return s3errs.ErrNotImplemented // versioning not supported
 	}
@@ -782,6 +800,10 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 
 	if r.Header.Get("If-None-Match") == etag {
 		return s3errs.ErrNotModified
+	}
+
+	if obj.PartsCount != nil {
+		w.Header().Set("x-amz-mp-parts-count", fmt.Sprintf("%d", *obj.PartsCount))
 	}
 
 	lastModified, _ := time.Parse(http.TimeFormat, obj.Metadata["Last-Modified"])

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -161,7 +161,7 @@ func (s *s3) copyObject(w http.ResponseWriter, r *http.Request, accessKeyID, dst
 	ifMatch := r.Header.Get("X-Amz-Copy-Source-If-Match")
 	ifNoneMatch := r.Header.Get("X-Amz-Copy-Source-If-None-Match")
 	if ifMatch != "" || ifNoneMatch != "" {
-		obj, err := s.backend.HeadObject(r.Context(), &accessKeyID, srcBucket, srcObject, nil)
+		obj, err := s.backend.HeadObject(r.Context(), &accessKeyID, srcBucket, srcObject, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -144,6 +144,109 @@ func TestGetAndHeadObject(t *testing.T) {
 	}
 }
 
+func TestGetAndHeadObjectPart(t *testing.T) {
+	s3Tester := testutil.NewTester(t)
+
+	const (
+		bucket = "multipart-bucket"
+		object = "object"
+	)
+
+	// create bucket
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	// prepare part data
+	p1Data := bytes.Repeat([]byte("a"), int(s3.MinUploadPartSize))
+	p2Data := bytes.Repeat([]byte("b"), int(s3.MinUploadPartSize))
+	p3Data := []byte("c")
+	data := append(append(p1Data, p2Data...), p3Data...)
+
+	// initiate multipart upload
+	uploadID, parts := newTestMultipartUpload(t, s3Tester, bucket, object, [][]byte{p1Data, p2Data, p3Data})
+
+	// complete the multipart upload
+	completed, err := s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, uploadID, parts)
+	if err != nil {
+		t.Fatal(err)
+	} else if completed.ETag == nil {
+		t.Fatal("expected ETag in completion response")
+	}
+
+	assertObject := func(t *testing.T, obj *s3.Object, head bool, partNumber int32) {
+		t.Helper()
+
+		var start, end int64
+		switch partNumber {
+		case 1:
+			start = 0
+			end = s3.MinUploadPartSize - 1
+		case 2:
+			start = s3.MinUploadPartSize
+			end = s3.MinUploadPartSize*2 - 1
+		case 3:
+			start = s3.MinUploadPartSize * 2
+			end = s3.MinUploadPartSize * 2
+		}
+
+		expected := data[start : end+1]
+		expectedHash := md5.Sum(expected)
+
+		if obj.ContentMD5 != expectedHash {
+			t.Fatal("hash mismatch", obj.ContentMD5, expectedHash[:])
+		} else if obj.Size != int64(len(data)) {
+			t.Fatalf("size mismatch: expected %d, got %d", len(data), obj.Size)
+		} else if obj.PartsCount == nil || *obj.PartsCount != 3 {
+			t.Fatalf("parts count mismatch: expected %d, got %d", 3, obj.PartsCount)
+		}
+
+		if !head {
+			if content, err := io.ReadAll(obj.Body); err != nil {
+				t.Fatal(err)
+			} else if !bytes.Equal(content, expected) {
+				t.Fatal("data mismatch", len(content), len(expected))
+			}
+		}
+	}
+
+	tests := []struct {
+		name string
+		part int32
+	}{
+		{
+			name: "PartNumber-1",
+			part: 1,
+		},
+		{
+			name: "PartNumber-2",
+			part: 2,
+		},
+		{
+			name: "PartNumber-3",
+			part: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// HEAD Object
+			obj, err := s3Tester.HeadObjectPart(t.Context(), bucket, object, tc.part)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertObject(t, obj, true, tc.part)
+
+			// GET Object
+			obj, err = s3Tester.GetObjectPart(t.Context(), bucket, object, tc.part)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertObject(t, obj, false, tc.part)
+		})
+	}
+}
+
 func TestPutObject(t *testing.T) {
 	test := func(t *testing.T, s3Tester *testutil.S3Tester) {
 		data := frand.Bytes(100)

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -81,7 +81,8 @@ type Backend interface {
 	// GetObject retrieves the object with the given key from the specified
 	// bucket for the user identified by the given access key. The provided
 	// range is either nil if no range was requested, or contains the requested,
-	// byte range.
+	// byte range. If partNumber is not nil, the specified part of a multipart
+	// upload is retrieved, this can not be combined with a byte range.
 	//
 	// - If the access key does not have permission to access the object,
 	//   [ErrAccessDenied] must be returned. A 'nil' accessKeyID indicates the
@@ -94,7 +95,7 @@ type Backend interface {
 	//
 	// - If the requested range is not satisfiable, [ErrInvalidRange] must be
 	//   returned. You can use the 'Range' method on 'rnge' for that.
-	GetObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *ObjectRangeRequest) (*Object, error)
+	GetObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *ObjectRangeRequest, partNumber *int32) (*Object, error)
 
 	// HeadBucket checks if the bucket with the given name exists and is
 	// accessible for the user identified by the given access key.
@@ -107,7 +108,7 @@ type Backend interface {
 
 	// HeadObject is like GetObject but only retrieves the metadata of the
 	// object and returns an empty body.
-	HeadObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *ObjectRangeRequest) (*Object, error)
+	HeadObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *ObjectRangeRequest, partNumber *int32) (*Object, error)
 
 	// ListBuckets lists all available buckets for the user identified by the
 	// given access key.

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -31,13 +31,13 @@ func (s *Sia) DeleteObject(ctx context.Context, accessKeyID, bucket, object stri
 // bucket for the user identified by the given access key. The provided
 // range is either nil if no range was requested, or contains the requested,
 // byte range.
-func (s *Sia) GetObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *s3.ObjectRangeRequest) (*s3.Object, error) {
+func (s *Sia) GetObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *s3.ObjectRangeRequest, _ *int32) (*s3.Object, error) {
 	return s.headOrGetObject(ctx, accessKeyID, bucket, object, rnge, false)
 }
 
 // HeadObject is like GetObject but only retrieves the metadata of the
 // object and returns an empty body.
-func (s *Sia) HeadObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *s3.ObjectRangeRequest) (*s3.Object, error) {
+func (s *Sia) HeadObject(ctx context.Context, accessKeyID *string, bucket, object string, rnge *s3.ObjectRangeRequest, _ *int32) (*s3.Object, error) {
 	return s.headOrGetObject(ctx, accessKeyID, bucket, object, rnge, true)
 }
 


### PR DESCRIPTION
Both `HeadObject` and `GetObject` have a `PartNumber` parameter that allows querying or fetching information about that part of an object that was uploaded using multipart uploads.  That means we have to keep track of this information for as long as the object exists. This was highlighted by the lack of a `PartsCount` header in the s3 tests, this PR fixes two or three tests from the multipart test suite.