### PR TITLE
Fix `BenchmarkListObjects` nits

### DIFF
--- a/sia/persist/sqlite/objects_test.go
+++ b/sia/persist/sqlite/objects_test.go
@@ -506,22 +506,38 @@ func BenchmarkListObjects(b *testing.B) {
 
 	b.Run("root_delimiter", func(b *testing.B) {
 		for b.Loop() {
-			result, err := store.ListObjects(nil, bucket, s3.Prefix{
-				Delimiter:    "/",
-				HasDelimiter: true,
-			}, s3.ListObjectsPage{MaxKeys: maxKeys})
-			if err != nil {
-				b.Fatal(err)
-			} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
-				b.Fatal("no results")
+			var marker *string
+			for {
+				result, err := store.ListObjects(nil, bucket, s3.Prefix{
+					Delimiter:    "/",
+					HasDelimiter: true,
+				}, s3.ListObjectsPage{MaxKeys: maxKeys, Marker: marker})
+				if err != nil {
+					b.Fatal(err)
+				} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
+					b.Fatal("no results")
+				}
+				if !result.IsTruncated {
+					break
+				}
+				marker = &result.NextMarker
 			}
 		}
 	})
 
 	b.Run("random_without_delimiter", func(b *testing.B) {
 		for b.Loop() {
+			var prefix string
+			switch frand.Intn(3) {
+			case 0:
+				prefix = fmt.Sprintf("%d/", frand.Intn(dir1))
+			case 1:
+				prefix = fmt.Sprintf("%d/%d/", frand.Intn(dir1), frand.Intn(dir2))
+			case 2:
+				prefix = fmt.Sprintf("%d/%d/%d/", frand.Intn(dir1), frand.Intn(dir2), frand.Intn(dir3))
+			}
 			result, err := store.ListObjects(nil, bucket, s3.Prefix{
-				Prefix:    fmt.Sprintf("%d/%d/", frand.Intn(dir1), frand.Intn(dir2)),
+				Prefix:    prefix,
 				HasPrefix: true,
 			}, s3.ListObjectsPage{MaxKeys: maxKeys})
 			if err != nil {
@@ -532,7 +548,7 @@ func BenchmarkListObjects(b *testing.B) {
 		}
 	})
 
-	b.Run("random_with_root_delimiter", func(b *testing.B) {
+	b.Run("random_with_delimiter", func(b *testing.B) {
 		for b.Loop() {
 			result, err := store.ListObjects(nil, bucket, s3.Prefix{
 				Prefix:       fmt.Sprintf("%d/%d/", frand.Intn(dir1), frand.Intn(dir2)),


### PR DESCRIPTION
Fix unfinished nits from #53

Specifically:
```
>    b.Run("random_without_delimiter", func(b *testing.B) {

nit the prefix is always at the same level

>   b.Run("root_delimiter", func(b *testing.B) {

nit this is fetching the same objects over and over again, if the result is truncated we could page through the root directory and fetch all objects and prefixes at that level

>   b.Run("random_with_root_delimiter", func(b *testing.B) {

nit would update the name here with_root_delimiter - the delimiter here is a slash, it's not related to listing at the root, especially since in this case we list objects at a prefix 2 levels down
```

New results are more or less the same:
```
BenchmarkListObjects/no_delimiter_no_prefix
BenchmarkListObjects/no_delimiter_no_prefix-4         	     164	   8220224 ns/op
BenchmarkListObjects/root_delimiter
BenchmarkListObjects/root_delimiter-4                 	      16	  85563036 ns/op
BenchmarkListObjects/random_without_delimiter
BenchmarkListObjects/random_without_delimiter-4       	     511	   3049035 ns/op
BenchmarkListObjects/random_with_delimiter
BenchmarkListObjects/random_with_delimiter-4          	    1192	    960306 ns/op
BenchmarkListObjects/folder_bottom_delimiter
BenchmarkListObjects/folder_bottom_delimiter-4        	    6873	    271411 ns/op
BenchmarkListObjects/folder_delimiter
BenchmarkListObjects/folder_delimiter-4               	    1479	   1111653 ns/op
```
