### PR TITLE
Add `WithKeyPair` option to Sia backend

### DIFF
--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -208,7 +208,7 @@ func main() {
 		checkFatalError("failed to get app key from database", err)
 	}
 
-	backend, err := sia.New(ctx, sia.NewSDK(sdkClient), store, cfg.Directory, sia.WithKeyPair(cfg.Sia.AccessKey, cfg.Sia.AccessKey, cfg.Sia.SecretKey))
+	backend, err := sia.New(ctx, sia.NewSDK(sdkClient), store, cfg.Directory, sia.WithKeyPair(cfg.Sia.AccessKey, cfg.Sia.SecretKey))
 	if err != nil {
 		checkFatalError("failed to create Sia backend", err)
 	}

--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -208,7 +208,7 @@ func main() {
 		checkFatalError("failed to get app key from database", err)
 	}
 
-	backend, err := sia.New(ctx, sia.NewSDK(sdkClient), store, cfg.Directory, cfg.Sia.AccessKey, cfg.Sia.SecretKey)
+	backend, err := sia.New(ctx, sia.NewSDK(sdkClient), store, cfg.Directory, sia.WithKeyPair(cfg.Sia.AccessKey, cfg.Sia.AccessKey, cfg.Sia.SecretKey))
 	if err != nil {
 		checkFatalError("failed to create Sia backend", err)
 	}

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -34,18 +34,10 @@ func WithLogger(logger *zap.Logger) Option {
 }
 
 // WithKeyPair adds a key pair to the MemoryBackend.
-func WithKeyPair(owner, accessKeyID, secretKey string) func(*Sia) {
+func WithKeyPair(accessKeyID, secretKey string) func(*Sia) {
 	return func(mb *Sia) {
-		mb.accessKeys[accessKeyID] = accessKey{
-			owner:  owner,
-			secret: auth.SecretAccessKey(secretKey),
-		}
+		mb.accessKeys[accessKeyID] = auth.SecretAccessKey(secretKey)
 	}
-}
-
-type accessKey struct {
-	owner  string
-	secret auth.SecretAccessKey
 }
 
 // Sia implements the s3.Backend interface for storing data on Sia.
@@ -55,7 +47,7 @@ type Sia struct {
 	store  Store
 
 	directory  string
-	accessKeys map[string]accessKey
+	accessKeys map[string]auth.SecretAccessKey
 }
 
 // SDK describes the SDK used to interact with Sia.
@@ -97,7 +89,7 @@ func New(ctx context.Context, sdk SDK, store Store, directory string, opts ...Op
 		store:  store,
 
 		directory:  directory,
-		accessKeys: make(map[string]accessKey),
+		accessKeys: make(map[string]auth.SecretAccessKey),
 	}
 	for _, opt := range opts {
 		opt(sia)
@@ -112,9 +104,9 @@ func New(ctx context.Context, sdk SDK, store Store, directory string, opts ...Op
 // LoadSecret loads the secret key for the given access key ID. If the access
 // key wasn't found, the error s3errs.ErrInvalidAccessKeyID is returned.
 func (s *Sia) LoadSecret(ctx context.Context, accessKeyID string) (auth.SecretAccessKey, error) {
-	key, ok := s.accessKeys[accessKeyID]
+	secret, ok := s.accessKeys[accessKeyID]
 	if !ok {
 		return nil, s3errs.ErrInvalidAccessKeyId
 	}
-	return slices.Clone(key.secret), nil
+	return slices.Clone(secret), nil
 }

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -33,15 +33,29 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
+// WithKeyPair adds a key pair to the MemoryBackend.
+func WithKeyPair(owner, accessKeyID, secretKey string) func(*Sia) {
+	return func(mb *Sia) {
+		mb.accessKeys[accessKeyID] = accessKey{
+			owner:  owner,
+			secret: auth.SecretAccessKey(secretKey),
+		}
+	}
+}
+
+type accessKey struct {
+	owner  string
+	secret auth.SecretAccessKey
+}
+
 // Sia implements the s3.Backend interface for storing data on Sia.
 type Sia struct {
 	sdk    SDK
 	logger *zap.Logger
 	store  Store
 
-	directory string
-	accessKey string
-	secretKey auth.SecretAccessKey
+	directory  string
+	accessKeys map[string]accessKey
 }
 
 // SDK describes the SDK used to interact with Sia.
@@ -71,11 +85,7 @@ type Store interface {
 }
 
 // New creates a new Sia backend instance.
-func New(ctx context.Context, sdk SDK, store Store, directory, accessKey, secretKey string, opts ...Option) (*Sia, error) {
-	if accessKey == "" || secretKey == "" {
-		return nil, fmt.Errorf("sia backend requires both access key and secret key")
-	}
-
+func New(ctx context.Context, sdk SDK, store Store, directory string, opts ...Option) (*Sia, error) {
 	directory = filepath.Join(directory, MultipartDirectory)
 	if err := os.MkdirAll(directory, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create multipart upload directory: %w", err)
@@ -86,12 +96,14 @@ func New(ctx context.Context, sdk SDK, store Store, directory, accessKey, secret
 		sdk:    sdk,
 		store:  store,
 
-		directory: directory,
-		accessKey: accessKey,
-		secretKey: auth.SecretAccessKey(secretKey),
+		directory:  directory,
+		accessKeys: make(map[string]accessKey),
 	}
 	for _, opt := range opts {
 		opt(sia)
+	}
+	if len(sia.accessKeys) == 0 {
+		return nil, fmt.Errorf("sia backend requires both access key and secret key")
 	}
 
 	return sia, nil
@@ -100,8 +112,9 @@ func New(ctx context.Context, sdk SDK, store Store, directory, accessKey, secret
 // LoadSecret loads the secret key for the given access key ID. If the access
 // key wasn't found, the error s3errs.ErrInvalidAccessKeyID is returned.
 func (s *Sia) LoadSecret(ctx context.Context, accessKeyID string) (auth.SecretAccessKey, error) {
-	if accessKeyID != s.accessKey {
+	key, ok := s.accessKeys[accessKeyID]
+	if !ok {
 		return nil, s3errs.ErrInvalidAccessKeyId
 	}
-	return slices.Clone(s.secretKey), nil
+	return slices.Clone(key.secret), nil
 }

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -33,7 +33,7 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
-// WithKeyPair adds a key pair to the MemoryBackend.
+// WithKeyPair adds a key pair to the Sia backend.
 func WithKeyPair(accessKeyID, secretKey string) func(*Sia) {
 	return func(mb *Sia) {
 		mb.accessKeys[accessKeyID] = auth.SecretAccessKey(secretKey)

--- a/sia/sia_test.go
+++ b/sia/sia_test.go
@@ -92,7 +92,7 @@ func NewTester(t testing.TB, opts ...testutil.TesterOption) *testutil.S3Tester {
 }
 
 func NewCustomTester(t testing.TB, dir string, store sia.Store, sdk sia.SDK, log *zap.Logger, opts ...testutil.TesterOption) *testutil.S3Tester {
-	backend, err := sia.New(context.Background(), sdk, store, dir, sia.WithKeyPair(testutil.Owner, testutil.AccessKeyID, testutil.SecretAccessKey),
+	backend, err := sia.New(context.Background(), sdk, store, dir, sia.WithKeyPair(testutil.AccessKeyID, testutil.SecretAccessKey),
 		sia.WithLogger(log))
 	if err != nil {
 		t.Fatal(err)

--- a/sia/sia_test.go
+++ b/sia/sia_test.go
@@ -92,7 +92,7 @@ func NewTester(t testing.TB, opts ...testutil.TesterOption) *testutil.S3Tester {
 }
 
 func NewCustomTester(t testing.TB, dir string, store sia.Store, sdk sia.SDK, log *zap.Logger, opts ...testutil.TesterOption) *testutil.S3Tester {
-	backend, err := sia.New(context.Background(), sdk, store, dir, testutil.AccessKeyID, testutil.SecretAccessKey,
+	backend, err := sia.New(context.Background(), sdk, store, dir, sia.WithKeyPair(testutil.Owner, testutil.AccessKeyID, testutil.SecretAccessKey),
 		sia.WithLogger(log))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
To run our s3-tests on a Sia backend we need to be able to pass multiple access key pairs.