### PR TITLE
Allow empty objects

### DIFF
--- a/sia/objects.go
+++ b/sia/objects.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SiaFoundation/s3d/s3"
 	"github.com/SiaFoundation/s3d/s3/s3errs"
 	"github.com/SiaFoundation/s3d/sia/objects"
+	"go.sia.tech/core/types"
 	"go.uber.org/zap"
 )
 
@@ -132,6 +133,12 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 		return resp, nil
 	}
 
+	// handle empty objects without downloading from Sia
+	if obj.Size == 0 {
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return resp, nil
+	}
+
 	// TODO: once the indexer returns the full metadata we can cache it locally
 	// and avoid fetching it on-demand.
 	pinnedObj, err := s.sdk.Object(ctx, obj.ID)
@@ -196,10 +203,20 @@ func (s *Sia) PutObject(ctx context.Context, accessKeyID string, bucket, object 
 		inner: r,
 	}
 
-	// upload the data
-	obj, err := s.sdk.Upload(ctx, lr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to upload object: %w", err)
+	// handle empty object case
+	var objectID types.Hash256
+	if opts.ContentLength == 0 {
+		// drain reader
+		if _, err := io.Copy(io.Discard, lr); err != nil {
+			return nil, fmt.Errorf("failed to read object data: %w", err)
+		}
+	} else {
+		// upload the data
+		obj, err := s.sdk.Upload(ctx, lr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upload object: %w", err)
+		}
+		objectID = obj.ID()
 	}
 
 	// check content length
@@ -219,7 +236,7 @@ func (s *Sia) PutObject(ctx context.Context, accessKeyID string, bucket, object 
 
 	// store the object in the database
 	if err := s.store.PutObject(accessKeyID, bucket, object, &objects.Object{
-		ID:         obj.ID(),
+		ID:         objectID,
 		ContentMD5: contentMD5,
 		Meta:       opts.Meta,
 		Size:       lr.N,

--- a/sia/objects_test.go
+++ b/sia/objects_test.go
@@ -208,7 +208,7 @@ func TestPutObject(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		} else if obj.ContentMD5 != emptyMD5 {
-			t.Fatal("empty object hash mismatch", obj.ContentMD5, emptyMD5[:])
+			t.Fatal("empty object hash mismatch", obj.ContentMD5, emptyMD5)
 		} else if obj.Size != 0 {
 			t.Fatalf("empty object size mismatch: expected 0, got %d", obj.Size)
 		} else if !reflect.DeepEqual(obj.Metadata, metadata) {

--- a/sia/objects_test.go
+++ b/sia/objects_test.go
@@ -192,6 +192,34 @@ func TestPutObject(t *testing.T) {
 		// upload to a bucket that doesn't exist
 		_, err = s3Tester.PutObject(t.Context(), "nonexistent", object, bytes.NewReader(data), metadata)
 		testutil.AssertS3Error(t, s3errs.ErrNoSuchBucket, err)
+
+		// upload an empty object
+		emptyObject := "empty.txt"
+		emptyMD5 := md5.Sum([]byte{})
+		resp, err = s3Tester.PutObject(t.Context(), bucket, emptyObject, bytes.NewReader([]byte{}), metadata)
+		if err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(resp, emptyMD5[:]) {
+			t.Fatalf("empty object hash mismatch: expected %x, got %x", emptyMD5, resp)
+		}
+
+		// assert fetching the object works and the body is empty
+		obj, err = s3Tester.GetObject(t.Context(), bucket, emptyObject, nil)
+		if err != nil {
+			t.Fatal(err)
+		} else if obj.ContentMD5 != emptyMD5 {
+			t.Fatal("empty object hash mismatch", obj.ContentMD5, emptyMD5[:])
+		} else if obj.Size != 0 {
+			t.Fatalf("empty object size mismatch: expected 0, got %d", obj.Size)
+		} else if !reflect.DeepEqual(obj.Metadata, metadata) {
+			t.Fatal("empty object metadata mismatch", obj.Metadata)
+		}
+		body, err := io.ReadAll(obj.Body)
+		if err != nil {
+			t.Fatal(err)
+		} else if len(body) != 0 {
+			t.Fatalf("expected empty body, got %d bytes", len(body))
+		}
 	}
 
 	t.Run("http", func(t *testing.T) {


### PR DESCRIPTION
In S3 it's perfectly legal to upload an empty object, our indexer doesn't allow saving objects without slabs so we should handle it in s3d and skip the `sdk.Upload`. We're storing empty Object IDs though, which is not ideal but not a big deal I guess? 