### PR TITLE
Add `FetchOwner`

### DIFF
--- a/internal/testutil/backend.go
+++ b/internal/testutil/backend.go
@@ -41,7 +41,7 @@ type (
 	}
 
 	bucket struct {
-		owner   string // access key id of the owner
+		owner   string
 		objects map[string]*object
 	}
 
@@ -255,6 +255,13 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 		return nil, s3errs.ErrAccessDenied
 	}
 
+	var owner *s3.UserInfo
+	if page.FetchOwner != nil && *page.FetchOwner {
+		owner = &s3.UserInfo{
+			ID: bkt.owner,
+		}
+	}
+
 	// flatten the objects into a slice and sort them lexicographically
 	objects := slices.Collect(maps.Values(bkt.objects))
 	slices.SortFunc(objects, func(a, b *object) int {
@@ -289,10 +296,8 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 				Key:          obj.name,
 				LastModified: s3.NewContentTime(obj.lastModified),
 				ETag:         s3.FormatETag(obj.contentMD5[:]),
-				Owner: &s3.UserInfo{
-					ID: bkt.owner,
-				},
-				Size: int64(len(obj.data)),
+				Owner:        owner,
+				Size:         int64(len(obj.data)),
 			})
 		}
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -309,6 +309,7 @@ func (t *S3Tester) ListObjectsV2(ctx context.Context, bucket string, prefix, del
 	}
 	resp, err := t.client.ListObjectsV2(ctx, &service.ListObjectsV2Input{
 		Bucket:            aws.String(bucket),
+		FetchOwner:        page.FetchOwner,
 		ContinuationToken: page.Marker,
 		Delimiter:         delimiter,
 		MaxKeys:           maxKeys,

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -125,7 +125,7 @@ func (s *s3) listBuckets(w http.ResponseWriter, r *http.Request, accessKeyID *st
 	resp := &ListBucketsResponse{
 		Xmlns:   "http://s3.amazonaws.com/doc/2006-03-01/",
 		Buckets: buckets,
-		Owner:   globalUserInfo,
+		Owner:   GlobalUserInfo,
 	}
 	return writeXMLResponse(w, resp)
 }

--- a/s3/messages.go
+++ b/s3/messages.go
@@ -10,10 +10,10 @@ import (
 // Such as a VersionID or location.
 const Null = "null"
 
-// globalUserInfo is a static placeholder for all responses requiring user info.
+// GlobalUserInfo is a static placeholder for all responses requiring user info.
 // Once we add authentication, this will be passed tied to the authenticated
 // user and persisted in the backend.
-var globalUserInfo = &UserInfo{
+var GlobalUserInfo = &UserInfo{
 	ID:          "bcaf1ffd86f41161ca5fb16fd081034f",
 	DisplayName: "S3D",
 }

--- a/s3/multipart.go
+++ b/s3/multipart.go
@@ -311,8 +311,8 @@ func (s *s3) listMultipartUploads(w http.ResponseWriter, r *http.Request, access
 		resp.Uploads = append(resp.Uploads, ListedMultipartUpload{
 			Key:          upload.Key,
 			UploadID:     upload.UploadID.String(),
-			Initiator:    globalUserInfo,
-			Owner:        globalUserInfo,
+			Initiator:    GlobalUserInfo,
+			Owner:        GlobalUserInfo,
 			StorageClass: StorageClass("STANDARD"),
 			Initiated:    NewContentTime(upload.Initiated),
 		})
@@ -464,14 +464,14 @@ func (s *s3) listUploadParts(w http.ResponseWriter, r *http.Request, accessKeyID
 		}
 	}
 
-	resp.Owner = globalUserInfo
+	resp.Owner = GlobalUserInfo
 	if result.OwnerID != "" || result.OwnerDisplayName != "" {
 		resp.Owner = &UserInfo{
 			ID:          result.OwnerID,
 			DisplayName: result.OwnerDisplayName,
 		}
 	}
-	resp.Initiator = globalUserInfo
+	resp.Initiator = GlobalUserInfo
 	if result.InitiatorID != "" || result.InitiatorDisplayName != "" {
 		resp.Initiator = &UserInfo{
 			ID:          result.InitiatorID,

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -634,8 +634,8 @@ func metadataHeaders(headers map[string][]string, sizeLimit int) (map[string]str
 // ListObjectsPage specifies pagination options for listing objects in a bucket.
 type ListObjectsPage struct {
 	// FetchOwner specifies whether owner information should be included in
-	// the response. If true, the Owner field of returned objects will be set.
-	// If false, the Owner field will be nil.
+	// the response. If nil or false, the Owner field of returned objects will
+	// be nil. If true, the Owner field of returned objects will be set.
 	FetchOwner *bool
 
 	// Marker specifies the key in the bucket that represents the last item in

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -481,12 +481,6 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 		result.NextContinuationToken = base64.URLEncoding.EncodeToString([]byte(objects.NextMarker))
 	}
 
-	// if fetch-owner is not set, redact owner information
-	if fo, set := q["fetch-owner"]; !set || (len(fo) > 0 && fo[0] == "false") {
-		for _, v := range result.Contents {
-			v.Owner = nil
-		}
-	}
 	return writeXMLResponse(w, result)
 }
 
@@ -639,6 +633,11 @@ func metadataHeaders(headers map[string][]string, sizeLimit int) (map[string]str
 
 // ListObjectsPage specifies pagination options for listing objects in a bucket.
 type ListObjectsPage struct {
+	// FetchOwner specifies whether owner information should be included in
+	// the response. If true, the Owner field of returned objects will be set.
+	// If false, the Owner field will be nil.
+	FetchOwner *bool
+
 	// Marker specifies the key in the bucket that represents the last item in
 	// the previous page. The first key in the returned page will be the next
 	// lexicographically (UTF-8 binary) sorted key after Marker. If HasMarker is
@@ -721,7 +720,6 @@ func listObjectsPageFromQuery(query url.Values) (page ListObjectsPage, rerr erro
 	if err != nil {
 		return page, err
 	}
-
 	page.MaxKeys = maxKeys
 
 	if _, hasMarker := query["continuation-token"]; hasMarker {
@@ -740,6 +738,10 @@ func listObjectsPageFromQuery(query url.Values) (page ListObjectsPage, rerr erro
 		page.Marker = aws.String(query.Get("start-after"))
 	}
 
+	if query.Get("fetch-owner") == "true" {
+		page.FetchOwner = aws.Bool(true)
+	}
+
 	return page, nil
 }
 
@@ -751,6 +753,7 @@ func listObjectVersionsPageFromQuery(query url.Values) (page ListObjectsPage, re
 
 	page.MaxKeys = maxKeys
 	page.Marker = aws.String(query.Get("key-marker"))
+	page.FetchOwner = aws.Bool(true) // always fetch owner for versions endpoint
 
 	return page, nil
 }

--- a/sia/objects_test.go
+++ b/sia/objects_test.go
@@ -456,7 +456,7 @@ func TestListObjects(t *testing.T) {
 		}
 	})
 
-	// test list objects with an without owner
+	// test list objects with and without owner
 	t.Run("owner", func(t *testing.T) {
 		resp, err := s3Tester.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{
 			MaxKeys:    1,

--- a/sia/objects_test.go
+++ b/sia/objects_test.go
@@ -456,6 +456,43 @@ func TestListObjects(t *testing.T) {
 		}
 	})
 
+	// test list objects with an without owner
+	t.Run("owner", func(t *testing.T) {
+		resp, err := s3Tester.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{
+			MaxKeys:    1,
+			FetchOwner: aws.Bool(true),
+		})
+		if err != nil {
+			t.Fatal(err)
+		} else if len(resp.Contents) == 0 {
+			t.Fatal("expected at least one object")
+		}
+
+		obj := resp.Contents[0]
+		if obj.Owner == nil {
+			t.Fatal("expected owner to be set")
+		} else if obj.Owner.ID == nil || *obj.Owner.ID == "" {
+			t.Fatal("expected owner ID to be set")
+		} else if obj.Owner.DisplayName == nil || *obj.Owner.DisplayName == "" {
+			t.Fatal("expected owner DisplayName to be set")
+		}
+
+		resp, err = s3Tester.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{
+			MaxKeys:    1,
+			FetchOwner: aws.Bool(false),
+		})
+		if err != nil {
+			t.Fatal(err)
+		} else if len(resp.Contents) == 0 {
+			t.Fatal("expected at least one object")
+		}
+
+		obj = resp.Contents[0]
+		if obj.Owner != nil {
+			t.Fatal("expected owner to be nil")
+		}
+	})
+
 	// test listing from non-existent bucket
 	t.Run("nonexistent bucket", func(t *testing.T) {
 		_, err := s3Tester.ListObjectsV2(t.Context(), "nonexistent", nil, nil, s3.ListObjectsPage{})

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -131,6 +131,12 @@ func (s *Store) ListObjects(_ *string, bucket string, prefix s3.Prefix, page s3.
 		}
 	}
 
+	// prepare owner info if requested
+	var owner *s3.UserInfo
+	if page.FetchOwner != nil && *page.FetchOwner {
+		owner = s3.GlobalUserInfo
+	}
+
 	const maxObjsPerQuery = 100
 	err = s.transaction(func(tx *txn) error {
 		bid, err := bucketID(tx, bucket)
@@ -187,6 +193,7 @@ WHERE o.bucket_id = ?`
 						LastModified: s3.NewContentTime(obj.UpdatedAt),
 						ETag:         s3.FormatETag(obj.ContentMD5[:]),
 						Size:         int64(obj.Size),
+						Owner:        owner,
 					})
 					lastObj = obj.Name
 				}


### PR DESCRIPTION
In our s3-test suite there's a test that explicitly checks whether passing `FetchOwner=true|false` to ListObjects is reflected in the response. In the memory backend we can use the bucket owner, I figured it's probably fine to pass global user info in the Sia backend for now, seeing as we don't have owners yet. I decided to add it to `ListObjectsPage` which is perhaps a little awkward but imo better than asking for an extra `bool` parameter.