### PR TITLE
Fix ListObjects 

### DIFF
--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"strings"
 	"time"
 
 	"github.com/SiaFoundation/s3d/s3"
@@ -381,10 +380,6 @@ WHERE o.bucket_id = ?`
 
 		if !result.IsTruncated {
 			result.NextMarker = ""
-		} else if prefix.HasDelimiter && strings.HasSuffix(result.NextMarker, prefix.Delimiter) {
-			// NextMarker is a common prefix. Append \xFF to skip past all objects
-			// with that prefix on the next call.
-			result.NextMarker += "\xFF"
 		}
 
 		return nil

--- a/sia/persist/sqlite/objects_test.go
+++ b/sia/persist/sqlite/objects_test.go
@@ -245,6 +245,30 @@ func TestListObjects(t *testing.T) {
 				}},
 		},
 		{
+			// regression: NextMarker can't contain \xFF when it is a
+			// common prefix, the \xFF skip is applied on re-entry via
+			// adjustMarkerForCommonPrefix
+			keys: []string{"a", "b/1", "b/2", "c"},
+			cases: []testCase{
+				{
+					name:           "CommonPrefixMarkerPage1",
+					delimiter:      "/",
+					maxKeys:        2,
+					objects:        []string{"a"},
+					commonPrefixes: []string{"b/"},
+					truncated:      true,
+					nextMarker:     "b/",
+				},
+				{
+					name:      "CommonPrefixMarkerPage2",
+					delimiter: "/",
+					marker:    "b/",
+					maxKeys:   2,
+					objects:   []string{"c"},
+				},
+			},
+		},
+		{
 			keys: largeDirectoryKeys,
 			cases: []testCase{
 				{


### PR DESCRIPTION
This PR removes `\xFF` from the `NextMarker`, it break pagination. We don't need to set it because it'll get set on re-entry. Added a regression test to confirm.