### PR TITLE
Defer deletion of opened uploads until the file isn't used anymore

### DIFF
--- a/sia/multipart.go
+++ b/sia/multipart.go
@@ -30,28 +30,20 @@ func randObjectName() string {
 	return fmt.Sprintf("%x.obj", uuid[:])
 }
 
-func (s *Sia) multipartUploadDir(uploadDir string) string {
-	return filepath.Join(s.directory, UploadsDirectory, uploadDir)
+func (s *Sia) multipartUploadPath(uploadID string) string {
+	return filepath.Join(s.directory, UploadsDirectory, uploadID)
 }
 
-func (s *Sia) createMultipartUploadDir(uploadID s3.UploadID) (string, error) {
-	uploadDir := s.multipartUploadDir(uploadID.String())
+func (s *Sia) createMultipartUploadDir(uploadID string) (string, error) {
+	uploadDir := s.multipartUploadPath(uploadID)
 	if err := os.Mkdir(uploadDir, 0700); err != nil {
 		return "", fmt.Errorf("failed to create upload directory: %w", err)
 	}
 	return uploadDir, nil
 }
 
-// TODO: when we start calling this after completing an upload, we need to make
-// sure we don't delete the dir while potentially still serving the data from
-// disk. That's because unlike with 'removeUpload', multipart uploads don't open
-// all file handles beforehand.
-func (s *Sia) removeMultipartUploadDir(uploadDir string) error {
-	return os.RemoveAll(s.multipartUploadDir(uploadDir))
-}
-
 func (s *Sia) multipartPartPath(uploadID s3.UploadID, partNumber int) string {
-	return filepath.Join(s.multipartUploadDir(uploadID.String()), fmt.Sprintf("%d", partNumber))
+	return filepath.Join(s.multipartUploadPath(uploadID.String()), fmt.Sprintf("%d", partNumber))
 }
 
 func (s *Sia) ensureMultipartPartDir(uploadID s3.UploadID, partNumber int) (string, error) {
@@ -71,7 +63,7 @@ func (s *Sia) CreateMultipartUpload(ctx context.Context, accessKeyID, bucket, ob
 
 	// create multipart upload directory
 	uploadID := s3.NewUploadID()
-	if _, err := s.createMultipartUploadDir(uploadID); err != nil {
+	if _, err := s.createMultipartUploadDir(uploadID.String()); err != nil {
 		return nil, err
 	}
 
@@ -114,7 +106,7 @@ func (s *Sia) AbortMultipartUpload(ctx context.Context, accessKeyID, bucket, obj
 	}
 
 	// remove multipart upload directory
-	if err := s.removeMultipartUploadDir(uploadID.String()); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := s.removeUpload(uploadID.String()); err != nil && !errors.Is(err, os.ErrNotExist) {
 		s.logger.Error("failed to remove multipart upload directory",
 			zap.Stringer("uploadID", uploadID),
 			zap.Error(err))
@@ -246,7 +238,7 @@ func (s *Sia) UploadPartCopy(ctx context.Context, accessKeyID, srcBucket, srcObj
 	// open a reader for the requested range of the source object
 	var src io.ReadCloser
 	if obj.FileName != nil {
-		src, err = s.openUpload(srcBucket, srcObject, obj.FileName, obj.IsMultipart(), opts.Range.Start)
+		src, err = s.openUpload(srcBucket, srcObject, obj.FileName, obj.IsMultipart(), &opts.Range)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open source upload: %w", err)
 		}
@@ -386,7 +378,7 @@ func (s *Sia) CompleteMultipartUpload(ctx context.Context, accessKeyID, bucket, 
 	}
 
 	// assert the upload directory exists
-	uploadDir := s.multipartUploadDir(uploadID.String())
+	uploadDir := s.multipartUploadPath(uploadID.String())
 	if _, err := os.Stat(uploadDir); err != nil {
 		return nil, fmt.Errorf("failed to stat upload directory: %w", err)
 	}

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -63,7 +63,11 @@ func (s *Sia) lockUpload(filename string) func() {
 		defer s.lockedUploadsMu.Unlock()
 
 		lu.refCount--
-		if lu.refCount == 0 {
+		if lu.refCount <= 0 {
+			_, locked := s.lockedUploads[filename]
+			if !locked {
+				panic(fmt.Sprintf("unlock called for filename %s that is not locked", filename))
+			}
 			delete(s.lockedUploads, filename)
 			if lu.deleted {
 				if err := os.RemoveAll(filepath.Join(s.uploadDir(), filename)); err != nil {
@@ -73,16 +77,19 @@ func (s *Sia) lockUpload(filename string) func() {
 				}
 			}
 		}
-		return
 	}
 }
 
-func (s *Sia) openUpload(bucket, name string, filename *string, multipart bool, r *s3.ObjectRange) (io.ReadCloser, error) {
+func (s *Sia) openUpload(bucket, name string, filename *string, multipart bool, r *s3.ObjectRange) (_ io.ReadCloser, err error) {
 	if filename == nil {
 		return nil, os.ErrNotExist
 	}
 	unlock := s.lockUpload(*filename)
-	defer unlock()
+	defer func() {
+		if err != nil {
+			unlock()
+		}
+	}()
 
 	var offset int64
 	if r != nil {

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -24,46 +24,113 @@ import (
 
 const metadataCacheLifetime = 24 * time.Hour
 
-type readCloser struct {
-	io.Reader
-	io.Closer
+type (
+	lockedUpload struct {
+		deleted  bool
+		refCount int
+	}
+
+	lockedUploadReader struct {
+		io.Reader
+		c      io.Closer
+		unlock func()
+	}
+)
+
+func (lr *lockedUploadReader) Close() error {
+	err := lr.c.Close()
+	lr.unlock()
+	return err
 }
 
 func (s *Sia) uploadDir() string {
 	return filepath.Join(s.directory, UploadsDirectory)
 }
 
-func (s *Sia) openUpload(bucket, name string, filename *string, multipart bool, offset int64) (io.ReadCloser, error) {
+func (s *Sia) lockUpload(filename string) func() {
+	s.lockedUploadsMu.Lock()
+	defer s.lockedUploadsMu.Unlock()
+
+	lu, ok := s.lockedUploads[filename]
+	if !ok {
+		lu = &lockedUpload{}
+		s.lockedUploads[filename] = lu
+	}
+	lu.refCount++
+
+	return func() {
+		s.lockedUploadsMu.Lock()
+		defer s.lockedUploadsMu.Unlock()
+
+		lu.refCount--
+		if lu.refCount == 0 {
+			delete(s.lockedUploads, filename)
+			if lu.deleted {
+				if err := os.RemoveAll(filepath.Join(s.uploadDir(), filename)); err != nil {
+					s.logger.Error("failed to remove upload upon unlock",
+						zap.String("filename", filename),
+						zap.Error(err))
+				}
+			}
+		}
+		return
+	}
+}
+
+func (s *Sia) openUpload(bucket, name string, filename *string, multipart bool, r *s3.ObjectRange) (io.ReadCloser, error) {
 	if filename == nil {
 		return nil, os.ErrNotExist
 	}
+	unlock := s.lockUpload(*filename)
+	defer unlock()
+
+	var offset int64
+	if r != nil {
+		offset = r.Start
+	}
+
+	var reader io.Reader
+	var closer io.Closer
 	if multipart {
 		parts, err := s.store.ObjectParts(bucket, name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get object parts: %w", err)
 		}
 		uploadDir := filepath.Join(s.uploadDir(), *filename)
-		return objects.NewReader(uploadDir, parts, offset)
-	}
-	f, err := os.Open(filepath.Join(s.uploadDir(), *filename))
-	if err != nil {
-		return nil, err
-	}
-	if offset > 0 {
-		if _, err := f.Seek(offset, io.SeekStart); err != nil {
-			f.Close()
+		r, err := objects.NewReader(uploadDir, parts, offset)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create multipart reader: %w", err)
+		}
+		reader, closer = r, r
+	} else {
+		f, err := os.Open(filepath.Join(s.uploadDir(), *filename))
+		if err != nil {
 			return nil, err
 		}
+		if offset > 0 {
+			if _, err := f.Seek(offset, io.SeekStart); err != nil {
+				f.Close()
+				return nil, err
+			}
+		}
+		reader, closer = f, f
 	}
-	return f, nil
+
+	if r != nil {
+		reader = io.LimitReader(reader, r.Length)
+	}
+	return &lockedUploadReader{Reader: reader, c: closer, unlock: unlock}, nil
 }
 
 func (s *Sia) removeUpload(fileName string) error {
-	// We use RemoveAll here since RemoveAll uses
-	// FILE_DISPOSITION_POSIX_SEMANTICS on supported Windows versions, which
-	// allows us to delete files that are currently being served without an error.
-	// Remove would fail on Windows which would lead to an unnecessary orphaned
-	// file.
+	s.lockedUploadsMu.Lock()
+	defer s.lockedUploadsMu.Unlock()
+
+	lu, ok := s.lockedUploads[fileName]
+	if ok {
+		lu.deleted = true
+		return nil
+	}
 	return os.RemoveAll(filepath.Join(s.uploadDir(), fileName))
 }
 
@@ -195,11 +262,7 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 
 	// read from disk if the object hasn't been uploaded yet
 	if obj.FileName != nil {
-		var offset int64
-		if resp.Range != nil {
-			offset = resp.Range.Start
-		}
-		rc, err := s.openUpload(bucket, object, obj.FileName, obj.IsMultipart(), offset)
+		rc, err := s.openUpload(bucket, object, obj.FileName, obj.IsMultipart(), resp.Range)
 		if errors.Is(err, fs.ErrNotExist) {
 			// possible race, check if the object was uploaded to Sia in the
 			// meantime
@@ -212,11 +275,7 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 		} else if err != nil {
 			return nil, fmt.Errorf("failed to open pending upload file: %w", err)
 		} else {
-			if resp.Range != nil {
-				resp.Body = readCloser{Reader: io.LimitReader(rc, resp.Range.Length), Closer: rc}
-			} else {
-				resp.Body = rc
-			}
+			resp.Body = rc
 			return resp, nil
 		}
 	}

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/SiaFoundation/s3d/s3"
@@ -76,6 +77,9 @@ type Sia struct {
 	uploadWastePct float64
 	uploadDisabled bool
 
+	lockedUploadsMu sync.Mutex
+	lockedUploads   map[string]*lockedUpload
+
 	tg     *threadgroup.ThreadGroup
 	logger *zap.Logger
 }
@@ -128,6 +132,7 @@ func New(ctx context.Context, sdk SDK, store Store, directory string, opts ...Op
 		directory:      directory,
 		accessKeys:     make(map[string]auth.SecretAccessKey),
 		uploadWastePct: DefaultUploadWastePct,
+		lockedUploads:  make(map[string]*lockedUpload),
 
 		logger: zap.NewNop(),
 		tg:     threadgroup.New(),

--- a/sia/upload.go
+++ b/sia/upload.go
@@ -232,7 +232,7 @@ func (s *Sia) uploadObjectGroup(ctx context.Context, group uploadGroup) error {
 
 	var objIdx []int
 	for i, obj := range group.objects {
-		rc, err := s.openUpload(obj.Bucket, obj.Name, &obj.Filename, obj.Multipart, 0)
+		rc, err := s.openUpload(obj.Bucket, obj.Name, &obj.Filename, obj.Multipart, nil)
 		if err != nil {
 			s.logger.Error("failed to open upload",
 				zap.String("bucket", obj.Bucket),
@@ -323,15 +323,13 @@ func (s *Sia) uploadObjectGroup(ctx context.Context, group uploadGroup) error {
 			zap.String("bucket", uploadObj.Bucket),
 			zap.String("name", uploadObj.Name))
 
-		if uploadObj.Multipart {
-			if err := s.removeMultipartUploadDir(uploadObj.Filename); err != nil {
+		if err := s.removeUpload(uploadObj.Filename); err != nil {
+			if uploadObj.Multipart {
 				s.logger.Error("failed to remove multipart upload directory",
 					zap.String("uploadID", uploadObj.Filename),
 					zap.Error(err))
-			}
-		} else {
-			if err := s.removeUpload(uploadObj.Filename); err != nil {
-				s.logger.Error("failed to remove file on disk",
+			} else {
+				s.logger.Error("failed to remove upload from disk",
 					zap.String("filename", uploadObj.Filename),
 					zap.Error(err))
 			}

--- a/sia/upload_test.go
+++ b/sia/upload_test.go
@@ -1,11 +1,14 @@
 package sia
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/SiaFoundation/s3d/sia/objects"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
@@ -132,8 +135,9 @@ func TestPrepareUploads(t *testing.T) {
 	}
 }
 
-// TestOpenAndRemoveUpload tests the locking mechanism that defers file
-// deletion until all locks are released.
+// TestOpenAndRemoveUpload tests that openUpload acquires a lock that is
+// released on ReadCloser.Close, and that removeUpload defers file deletion
+// until all open readers are closed.
 func TestOpenAndRemoveUpload(t *testing.T) {
 	dir := t.TempDir()
 	uploadsDir := filepath.Join(dir, UploadsDirectory)
@@ -141,7 +145,7 @@ func TestOpenAndRemoveUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Sia{directory: dir, lockedUploads: make(map[string]*lockedUpload)}
+	s := &Sia{directory: dir, lockedUploads: make(map[string]*lockedUpload), logger: zap.NewNop()}
 
 	// write random data to an upload file
 	data := frand.Bytes(256)
@@ -151,42 +155,61 @@ func TestOpenAndRemoveUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// acquire a lock on the upload
-	unlock := s.lockUpload(fileName)
+	// open the upload through the real entry point; this should acquire the lock
+	rc, err := s.openUpload("", "", &fileName, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// removeUpload while the lock is held should mark deleted but not
+	// the reader should return the file contents
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(got, data) {
+		t.Fatal("read data does not match written data")
+	}
+
+	// removeUpload while the reader is open should mark deleted but not
 	// remove the file from disk
 	if err := s.removeUpload(fileName); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filePath); err != nil {
-		t.Fatal("file should still exist on disk while lock is held:", err)
+		t.Fatal("file should still exist on disk while reader is open:", err)
 	}
 
-	// acquiring a second lock should also work
-	unlock2 := s.lockUpload(fileName)
+	// open a second reader on the same file; the deferred deletion should
+	// not fire until both are closed
+	rc2, err := s.openUpload("", "", &fileName, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// releasing the first lock should not remove the file yet because the
-	// second lock is still held
-	unlock()
+	// closing the first reader should not remove the file yet because the
+	// second reader is still open
+	if err := rc.Close(); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := os.Stat(filePath); err != nil {
-		t.Fatal("file should still exist on disk while second lock is held:", err)
+		t.Fatal("file should still exist on disk while second reader is open:", err)
 	}
 
-	// releasing the second lock should trigger the deferred removal
-	unlock2()
+	// closing the second reader should trigger the deferred removal
+	if err := rc2.Close(); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
-		t.Fatal("file should have been removed after all locks were released")
+		t.Fatal("file should have been removed after all readers were closed")
 	}
 
-	// unlocking an unlocked file should panic
+	// closing a reader twice should panic (matches lockUpload's double-unlock contract)
 	func() {
 		defer func() {
 			if r := recover(); r == nil {
-				t.Fatal("expected panic when unlocking an unlocked file")
+				t.Fatal("expected panic when closing an already-closed reader")
 			}
 		}()
-		unlock2()
+		_ = rc2.Close()
 	}()
 
 	// verify the lockedUploads map is cleaned up
@@ -196,7 +219,7 @@ func TestOpenAndRemoveUpload(t *testing.T) {
 	}
 	s.lockedUploadsMu.Unlock()
 
-	// removing a file without any lock should delete it immediately
+	// removing a file without any open reader should delete it immediately
 	fileName2 := "test-upload-2"
 	filePath2 := filepath.Join(uploadsDir, fileName2)
 	if err := os.WriteFile(filePath2, data, 0600); err != nil {
@@ -206,6 +229,6 @@ func TestOpenAndRemoveUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filePath2); !os.IsNotExist(err) {
-		t.Fatal("file should have been removed immediately when no lock is held")
+		t.Fatal("file should have been removed immediately when no reader is open")
 	}
 }

--- a/sia/upload_test.go
+++ b/sia/upload_test.go
@@ -179,6 +179,16 @@ func TestOpenAndRemoveUpload(t *testing.T) {
 		t.Fatal("file should have been removed after all locks were released")
 	}
 
+	// unlocking an unlocked file should panic
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic when unlocking an unlocked file")
+			}
+		}()
+		unlock2()
+	}()
+
 	// verify the lockedUploads map is cleaned up
 	s.lockedUploadsMu.Lock()
 	if _, ok := s.lockedUploads[fileName]; ok {

--- a/sia/upload_test.go
+++ b/sia/upload_test.go
@@ -1,8 +1,6 @@
 package sia
 
 import (
-	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -134,9 +132,8 @@ func TestPrepareUploads(t *testing.T) {
 	}
 }
 
-// TestOpenAndRemoveUpload tests that an upload file can be removed while it is
-// still open, and the open handle can still be read from and matches the
-// original data.
+// TestOpenAndRemoveUpload tests the locking mechanism that defers file
+// deletion until all locks are released.
 func TestOpenAndRemoveUpload(t *testing.T) {
 	dir := t.TempDir()
 	uploadsDir := filepath.Join(dir, UploadsDirectory)
@@ -144,34 +141,61 @@ func TestOpenAndRemoveUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Sia{directory: dir}
+	s := &Sia{directory: dir, lockedUploads: make(map[string]*lockedUpload)}
 
 	// write random data to an upload file
 	data := frand.Bytes(256)
 	fileName := "test-upload"
-	if err := os.WriteFile(filepath.Join(uploadsDir, fileName), data, 0600); err != nil {
+	filePath := filepath.Join(uploadsDir, fileName)
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
 		t.Fatal(err)
 	}
 
-	// open the upload
-	rc, err := s.openUpload("bucket", "name", &fileName, false, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// acquire a lock on the upload
+	unlock := s.lockUpload(fileName)
 
-	// remove the upload while the file handle is still open
+	// removeUpload while the lock is held should mark deleted but not
+	// remove the file from disk
 	if err := s.removeUpload(fileName); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := os.Stat(filePath); err != nil {
+		t.Fatal("file should still exist on disk while lock is held:", err)
+	}
 
-	// read from the still open handle and compare
-	got, err := io.ReadAll(rc)
-	if err != nil {
+	// acquiring a second lock should also work
+	unlock2 := s.lockUpload(fileName)
+
+	// releasing the first lock should not remove the file yet because the
+	// second lock is still held
+	unlock()
+	if _, err := os.Stat(filePath); err != nil {
+		t.Fatal("file should still exist on disk while second lock is held:", err)
+	}
+
+	// releasing the second lock should trigger the deferred removal
+	unlock2()
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Fatal("file should have been removed after all locks were released")
+	}
+
+	// verify the lockedUploads map is cleaned up
+	s.lockedUploadsMu.Lock()
+	if _, ok := s.lockedUploads[fileName]; ok {
+		t.Fatal("lockedUploads entry should have been cleaned up")
+	}
+	s.lockedUploadsMu.Unlock()
+
+	// removing a file without any lock should delete it immediately
+	fileName2 := "test-upload-2"
+	filePath2 := filepath.Join(uploadsDir, fileName2)
+	if err := os.WriteFile(filePath2, data, 0600); err != nil {
 		t.Fatal(err)
 	}
-	rc.Close()
-
-	if !bytes.Equal(got, data) {
-		t.Fatal("data read from open handle does not match original")
+	if err := s.removeUpload(fileName2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filePath2); !os.IsNotExist(err) {
+		t.Fatal("file should have been removed immediately when no lock is held")
 	}
 }


### PR DESCRIPTION
S3d serves files that aren't uploaded yet from disk. While doing so, the file might get uploaded and end up being deleted.
Depending on the operating system and file system this can lead to all sorts of different behavior.

This PR solves this by adding some basic reference counting which defers the deletion of the file until nothing is using it anymore. 