### PR TITLE
Fix PartsCount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 .vscode
 s3-tests/
 CLAUDE.md
+GeoLite2-City.mmdb

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -245,6 +245,44 @@ func TestGetAndHeadObjectPart(t *testing.T) {
 			assertObject(t, obj, false, tc.part)
 		})
 	}
+
+	// non-multipart object with part number
+	regular := "regular"
+	regularData := frand.Bytes(100)
+	regularHash := md5.Sum(regularData)
+	if _, err := s3Tester.PutObject(t.Context(), bucket, regular, bytes.NewReader(regularData), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// head part 1
+	obj, err := s3Tester.HeadObjectPart(t.Context(), bucket, regular, 1)
+	if err != nil {
+		t.Fatal(err)
+	} else if obj.PartsCount == nil || *obj.PartsCount != 1 {
+		t.Fatalf("expected parts count 1, got %v", obj.PartsCount)
+	} else if obj.ContentMD5 != regularHash {
+		t.Fatalf("expected MD5 %x, got %x", regularHash, obj.ContentMD5)
+	} else if obj.Size != int64(len(regularData)) {
+		t.Fatalf("expected size %d, got %d", len(regularData), obj.Size)
+	}
+
+	// get part 1
+	obj, err = s3Tester.GetObjectPart(t.Context(), bucket, regular, 1)
+	if err != nil {
+		t.Fatal(err)
+	} else if obj.PartsCount == nil || *obj.PartsCount != 1 {
+		t.Fatalf("expected parts count 1, got %v", obj.PartsCount)
+	}
+	content, err := io.ReadAll(obj.Body)
+	if err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(content, regularData) {
+		t.Fatal("data mismatch")
+	}
+
+	// invalid part number
+	_, err = s3Tester.GetObjectPart(t.Context(), bucket, regular, 2)
+	testutil.AssertS3Error(t, s3errs.ErrInvalidPart, err)
 }
 
 func TestPutObject(t *testing.T) {

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -231,6 +231,10 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 
 	var resp *s3.Object
 	if partNumber != nil {
+		partsCount := obj.PartsCount
+		if partsCount == 0 {
+			partsCount = 1
+		}
 		resp = &s3.Object{
 			Body:         nil,
 			ContentMD5:   obj.ContentMD5,
@@ -238,7 +242,7 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 			Metadata:     obj.Meta,
 			Range:        &s3.ObjectRange{Start: obj.Offset, Length: obj.Length},
 			Size:         obj.Length,
-			PartsCount:   aws.Int32(obj.PartsCount),
+			PartsCount:   aws.Int32(partsCount),
 		}
 	} else {
 		rnge, err := requestedRange.Range(obj.Length)

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -241,7 +241,7 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 			LastModified: obj.LastModified,
 			Metadata:     obj.Meta,
 			Range:        &s3.ObjectRange{Start: obj.Offset, Length: obj.Length},
-			Size:         obj.Length,
+			Size:         obj.Size,
 			PartsCount:   aws.Int32(partsCount),
 		}
 	} else {

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -231,10 +231,7 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 
 	var resp *s3.Object
 	if partNumber != nil {
-		partsCount := obj.PartsCount
-		if partsCount == 0 {
-			partsCount = 1
-		}
+		partsCount := min(obj.PartsCount, 1)
 		resp = &s3.Object{
 			Body:         nil,
 			ContentMD5:   obj.ContentMD5,

--- a/sia/objects/objects.go
+++ b/sia/objects/objects.go
@@ -27,6 +27,7 @@ type Object struct {
 	Meta         map[string]string
 	Offset       int64
 	Length       int64
+	Size         int64
 	ContentMD5   [16]byte
 	LastModified time.Time
 

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -113,6 +113,7 @@ func getObject(tx *txn, obj *objects.Object, bid int64, name string, partNumber 
 			FROM objects
 			WHERE bucket_id = $1 AND name = $2
 		`, bid, name).Scan(&obj.FileName, &objectID, (*sqlMetaJSON)(&obj.Meta), (*sqlTime)(&obj.LastModified), &obj.Length, (*sqlMD5)(&obj.ContentMD5), &siaObj, (*sqlTime)(&obj.CachedAt))
+		obj.Size = obj.Length
 		if objectID.Valid {
 			obj.ID = (*types.Hash256)(&objectID.V)
 		}
@@ -131,11 +132,11 @@ func getObject(tx *txn, obj *objects.Object, bid int64, name string, partNumber 
 	var partObjID sql.Null[sqlHash256]
 	var siaObj sql.Null[sqlSiaObject]
 	err = tx.QueryRow(`
-		SELECT o.object_id, o.filename, o.metadata, o.updated_at, p.offset, p.content_length, p.content_md5, o.sia_object, o.cached_at
+		SELECT o.object_id, o.filename, o.metadata, o.updated_at, o.size, p.offset, p.content_length, p.content_md5, o.sia_object, o.cached_at
 		FROM object_parts p
 		JOIN objects o ON o.bucket_id = p.bucket_id AND o.name = p.name
 		WHERE o.bucket_id = $1 AND o.name = $2 AND p.part_number = $3
-	`, bid, name, *partNumber).Scan(&partObjID, &obj.FileName, (*sqlMetaJSON)(&obj.Meta), (*sqlTime)(&obj.LastModified), &obj.Offset, &obj.Length, (*sqlMD5)(&obj.ContentMD5), &siaObj, (*sqlTime)(&obj.CachedAt))
+	`, bid, name, *partNumber).Scan(&partObjID, &obj.FileName, (*sqlMetaJSON)(&obj.Meta), (*sqlTime)(&obj.LastModified), &obj.Size, &obj.Offset, &obj.Length, (*sqlMD5)(&obj.ContentMD5), &siaObj, (*sqlTime)(&obj.CachedAt))
 	if partObjID.Valid {
 		obj.ID = (*types.Hash256)(&partObjID.V)
 	}

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -103,11 +103,8 @@ func getObject(tx *txn, obj *objects.Object, bid int64, name string, partNumber 
 
 	// return full object if no part specified
 	if partNumber == nil || obj.PartsCount == 0 {
-		if obj.PartsCount == 0 && partNumber != nil {
-			if *partNumber != 1 {
-				return s3errs.ErrInvalidPart
-			}
-			obj.PartsCount = *partNumber
+		if obj.PartsCount == 0 && partNumber != nil && *partNumber != 1 {
+			return s3errs.ErrInvalidPart
 		}
 		var objectID sql.Null[sqlHash256]
 		var siaObj sql.Null[sqlSiaObject]
@@ -126,20 +123,24 @@ func getObject(tx *txn, obj *objects.Object, bid int64, name string, partNumber 
 	}
 
 	// return error if part number is invalid
-	if partNumber != nil && obj.PartsCount > 0 && *partNumber > int32(obj.PartsCount) {
+	if *partNumber > int32(obj.PartsCount) {
 		return s3errs.ErrInvalidPart
 	}
 
 	// part specified, return part info
 	var partObjID sql.Null[sqlHash256]
+	var siaObj sql.Null[sqlSiaObject]
 	err = tx.QueryRow(`
-		SELECT o.object_id, o.metadata, o.updated_at, p.offset, p.content_length, p.content_md5
+		SELECT o.object_id, o.filename, o.metadata, o.updated_at, p.offset, p.content_length, p.content_md5, o.sia_object, o.cached_at
 		FROM object_parts p
 		JOIN objects o ON o.bucket_id = p.bucket_id AND o.name = p.name
 		WHERE o.bucket_id = $1 AND o.name = $2 AND p.part_number = $3
-	`, bid, name, *partNumber).Scan(&partObjID, (*sqlMetaJSON)(&obj.Meta), (*sqlTime)(&obj.LastModified), &obj.Offset, &obj.Length, (*sqlMD5)(&obj.ContentMD5))
+	`, bid, name, *partNumber).Scan(&partObjID, &obj.FileName, (*sqlMetaJSON)(&obj.Meta), (*sqlTime)(&obj.LastModified), &obj.Offset, &obj.Length, (*sqlMD5)(&obj.ContentMD5), &siaObj, (*sqlTime)(&obj.CachedAt))
 	if partObjID.Valid {
 		obj.ID = (*types.Hash256)(&partObjID.V)
+	}
+	if siaObj.Valid {
+		obj.SiaObject = (*slabs.SealedObject)(&siaObj.V)
 	}
 	return err
 }

--- a/sia/persist/sqlite/objects_test.go
+++ b/sia/persist/sqlite/objects_test.go
@@ -109,6 +109,8 @@ func TestGetObject(t *testing.T) {
 		t.Fatal(err)
 	} else if objPart1.ID == nil || *objPart1.ID != objID {
 		t.Fatalf("expected object ID %v, got %v", objID, objPart1.ID)
+	} else if objPart1.PartsCount != 0 {
+		t.Fatalf("expected parts count 0, got %d", objPart1.PartsCount)
 	} else if objPart1.Offset != 0 {
 		t.Fatalf("expected object offset 0, got %d", objPart1.Offset)
 	} else if objPart1.Length != int64(objLength) {
@@ -117,6 +119,8 @@ func TestGetObject(t *testing.T) {
 		t.Fatalf("expected object MD5 %v, got %v", objMD5, objPart1.ContentMD5)
 	} else if len(objPart1.Meta) != len(objMeta) || objPart1.Meta["foo"] != "bar" {
 		t.Fatalf("expected object metadata %v, got %v", objMeta, objPart1.Meta)
+	} else if objPart1.SiaObject == nil {
+		t.Fatal("expected sia object to be set")
 	}
 
 	// mark multipart object as uploaded
@@ -141,6 +145,8 @@ func TestGetObject(t *testing.T) {
 		t.Fatalf("expected object MD5 %v, got %v", part2MD5, multipartPart2.ContentMD5)
 	} else if len(multipartPart2.Meta) != len(multipartMeta) || multipartPart2.Meta["baz"] != "qux" {
 		t.Fatalf("expected object metadata %v, got %v", multipartMeta, multipartPart2.Meta)
+	} else if multipartPart2.SiaObject == nil {
+		t.Fatal("expected sia object to be set")
 	}
 
 	// get object with invalid part number

--- a/sia/persist/sqlite/objects_test.go
+++ b/sia/persist/sqlite/objects_test.go
@@ -115,6 +115,8 @@ func TestGetObject(t *testing.T) {
 		t.Fatalf("expected object offset 0, got %d", objPart1.Offset)
 	} else if objPart1.Length != int64(objLength) {
 		t.Fatalf("expected object length %d, got %d", objLength, objPart1.Length)
+	} else if objPart1.Size != int64(objLength) {
+		t.Fatalf("expected object size %d, got %d", objLength, objPart1.Size)
 	} else if objPart1.ContentMD5 != objMD5 {
 		t.Fatalf("expected object MD5 %v, got %v", objMD5, objPart1.ContentMD5)
 	} else if len(objPart1.Meta) != len(objMeta) || objPart1.Meta["foo"] != "bar" {
@@ -141,6 +143,8 @@ func TestGetObject(t *testing.T) {
 		t.Fatalf("expected object offset %d, got %d", s3.MinUploadPartSize, multipartPart2.Offset)
 	} else if multipartPart2.Length != 2 {
 		t.Fatalf("expected object length %d, got %d", 2, multipartPart2.Length)
+	} else if multipartPart2.Size != totalSize {
+		t.Fatalf("expected object size %d, got %d", totalSize, multipartPart2.Size)
 	} else if multipartPart2.ContentMD5 != part2MD5 {
 		t.Fatalf("expected object MD5 %v, got %v", part2MD5, multipartPart2.ContentMD5)
 	} else if len(multipartPart2.Meta) != len(multipartMeta) || multipartPart2.Meta["baz"] != "qux" {


### PR DESCRIPTION
When retrieving an object by part number, the parts count was incorrectly returned as 0 for non-multipart objects, and the part query was missing filename, sia_object, and cached_at fields which prevented serving part data from disk or Sia.