### PR TITLE
Handle `If-Modified-Since`

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -60,6 +60,7 @@ func (t *S3Tester) ChangeAccessKey(tb testing.TB, accessKeyID, secretKey string)
 	}
 }
 
+// Client returns the tester's S3 client.
 func (t *S3Tester) Client() *service.Client {
 	return t.client
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -60,6 +60,10 @@ func (t *S3Tester) ChangeAccessKey(tb testing.TB, accessKeyID, secretKey string)
 	}
 }
 
+func (t *S3Tester) Client() *service.Client {
+	return t.client
+}
+
 // AddObject adds an object to the in-memory S3 backend.
 func (t *S3Tester) AddObject(bucket, object string, data []byte, metadata map[string]string) error {
 	_, err := t.backend.PutObject(context.Background(), AccessKeyID, bucket, object, bytes.NewReader(data), s3.PutObjectOptions{

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -953,6 +953,7 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 
 	etag := FormatETag(obj.ContentMD5[:], 0)
 	w.Header().Set("ETag", etag)
+	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(http.TimeFormat))
 
 	if r.Header.Get("If-None-Match") == etag {
 		return s3errs.ErrNotModified
@@ -974,7 +975,6 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 	} else {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", obj.Size))
 	}
-	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(http.TimeFormat))
 
 	return nil
 }

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -963,9 +963,11 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 		w.Header().Set("x-amz-mp-parts-count", fmt.Sprintf("%d", *obj.PartsCount))
 	}
 
-	ifModifiedSince, _ := time.Parse(http.TimeFormat, r.Header.Get("If-Modified-Since"))
-	if !ifModifiedSince.IsZero() && !ifModifiedSince.Before(obj.LastModified) {
-		return s3errs.ErrNotModified
+	if r.Header.Get("If-None-Match") == "" {
+		ifModifiedSince, _ := time.Parse(http.TimeFormat, r.Header.Get("If-Modified-Since"))
+		if !ifModifiedSince.IsZero() && !ifModifiedSince.Before(obj.LastModified) {
+			return s3errs.ErrNotModified
+		}
 	}
 
 	w.Header().Set("Accept-Ranges", "bytes")

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -962,9 +962,8 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 		w.Header().Set("x-amz-mp-parts-count", fmt.Sprintf("%d", *obj.PartsCount))
 	}
 
-	lastModified, _ := time.Parse(http.TimeFormat, obj.Metadata["Last-Modified"])
 	ifModifiedSince, _ := time.Parse(http.TimeFormat, r.Header.Get("If-Modified-Since"))
-	if !lastModified.IsZero() && !ifModifiedSince.Before(lastModified) {
+	if !ifModifiedSince.IsZero() && !ifModifiedSince.Before(obj.LastModified) {
 		return s3errs.ErrNotModified
 	}
 

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -188,6 +188,19 @@ func TestGetAndHeadObject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// if-modified-since should be ignored when if-none-match is present per
+	// RFC 7232, even if if-modified-since alone would return 304
+	resp, err := s3Tester.Client().GetObject(t.Context(), &service.GetObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(object),
+		IfModifiedSince: aws.Time(time.Now().Add(time.Hour)),
+		IfNoneMatch:     aws.String("\"nonexistent\""),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
 }
 
 func TestGetAndHeadObjectPart(t *testing.T) {

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SiaFoundation/s3d/s3"
 	"github.com/SiaFoundation/s3d/s3/s3errs"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	service "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"lukechampine.com/frand"
 )
@@ -141,6 +142,51 @@ func TestGetAndHeadObject(t *testing.T) {
 			}
 			assertObject(t, obj, false, tc.rnge)
 		})
+	}
+
+	// if-modified-since with a time in the past should return 200
+	getResp, err := s3Tester.Client().GetObject(t.Context(), &service.GetObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(object),
+		IfModifiedSince: aws.Time(time.Now().Add(-time.Hour)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	getResp.Body.Close()
+
+	// if-modified-since with a time in the future should return 304
+	_, err = s3Tester.Client().GetObject(t.Context(), &service.GetObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(object),
+		IfModifiedSince: aws.Time(time.Now().Add(time.Hour)),
+	})
+	testutil.AssertS3StatusCode(t, s3errs.ErrNotModified, err)
+
+	// if-modified-since equal to last-modified should return 304
+	_, err = s3Tester.Client().GetObject(t.Context(), &service.GetObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(object),
+		IfModifiedSince: getResp.LastModified,
+	})
+	testutil.AssertS3StatusCode(t, s3errs.ErrNotModified, err)
+
+	// head with if-modified-since in the future should return 304
+	_, err = s3Tester.Client().HeadObject(t.Context(), &service.HeadObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(object),
+		IfModifiedSince: aws.Time(time.Now().Add(time.Hour)),
+	})
+	testutil.AssertS3StatusCode(t, s3errs.ErrNotModified, err)
+
+	// head with if-modified-since in the past should return 200
+	_, err = s3Tester.Client().HeadObject(t.Context(), &service.HeadObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(object),
+		IfModifiedSince: aws.Time(time.Now().Add(-time.Hour)),
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Found out `If-Modified-Since` was being ignored considering we compare it against `obj.Metadata["Last-Modified"]` which never gets populated.