### PR TITLE
Fix transaction idempotency

### DIFF
--- a/sia/persist/sqlite/buckets.go
+++ b/sia/persist/sqlite/buckets.go
@@ -64,6 +64,8 @@ func (s *Store) ListBuckets(accessKeyID string) ([]s3.BucketInfo, error) {
 		if err != nil {
 			return err
 		}
+		defer rows.Close()
+
 		for rows.Next() {
 			var createdAt time.Time
 			var name string
@@ -75,7 +77,7 @@ func (s *Store) ListBuckets(accessKeyID string) ([]s3.BucketInfo, error) {
 				CreationDate: s3.NewContentTime(createdAt),
 			})
 		}
-		return rows.Close()
+		return rows.Err()
 	})
 	return buckets, err
 }

--- a/sia/persist/sqlite/buckets.go
+++ b/sia/persist/sqlite/buckets.go
@@ -59,6 +59,7 @@ func (s *Store) HeadBucket(accessKeyID, bucket string) error {
 func (s *Store) ListBuckets(accessKeyID string) ([]s3.BucketInfo, error) {
 	var buckets []s3.BucketInfo
 	err := s.transaction(func(tx *txn) error {
+		buckets = buckets[:0] // reuse same slice if transaction retries
 		rows, err := tx.Query("SELECT name, created_at FROM buckets")
 		if err != nil {
 			return err

--- a/sia/persist/sqlite/multipart.go
+++ b/sia/persist/sqlite/multipart.go
@@ -166,6 +166,8 @@ func (s *Store) AbortMultipartUpload(bucket, name string, uploadID s3.UploadID) 
 func (s *Store) AddMultipartPart(bucket, name string, uploadID s3.UploadID, filename string, partNumber int, contentMD5 [16]byte, contentLength int64) (string, error) {
 	var prevFilename string
 	if err := s.transaction(func(tx *txn) error {
+		prevFilename = "" // reset per transaction attempt
+
 		bid, err := bucketID(tx, bucket)
 		if err != nil {
 			return err

--- a/sia/persist/sqlite/multipart.go
+++ b/sia/persist/sqlite/multipart.go
@@ -228,6 +228,8 @@ func (s *Store) HasMultipartUpload(bucket, name string, uploadID s3.UploadID) er
 func (s *Store) MultipartParts(bucket, name string, uploadID s3.UploadID) ([]objects.Part, error) {
 	var parts []objects.Part
 	if err := s.transaction(func(tx *txn) error {
+		parts = parts[:0] // reuse same slice if transaction retries
+
 		bid, err := bucketID(tx, bucket)
 		if err != nil {
 			return err
@@ -278,6 +280,10 @@ func (s *Store) ListParts(bucket, name string, uploadID s3.UploadID, partNumberM
 	}
 
 	if err := s.transaction(func(tx *txn) error {
+		res.Parts = res.Parts[:0] // reuse same slice if transaction retries
+		res.IsTruncated = false
+		res.NextPartNumberMarker = ""
+
 		bid, err := bucketID(tx, bucket)
 		if err != nil {
 			return err
@@ -364,6 +370,12 @@ func (s *Store) ListMultipartUploads(bucket string, prefix s3.Prefix, page s3.Li
 	}
 
 	err = s.transaction(func(tx *txn) error {
+		res.Uploads = res.Uploads[:0]               // reuse same slice if transaction retries
+		res.CommonPrefixes = res.CommonPrefixes[:0] // reuse same slice if transaction retries
+		res.IsTruncated = false                     // reset per transaction attempt
+		res.NextKeyMarker = ""                      // reset per transaction attempt
+		res.NextUploadIDMarker = ""                 // reset per transaction attempt
+
 		bid, err := bucketID(tx, bucket)
 		if err != nil {
 			return err

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -192,6 +192,8 @@ func (s *Store) MarkObjectUploaded(bucket, name string, contentMD5 [16]byte, sea
 // single transaction. It returns the number of rows that were updated.
 func (s *Store) UpdateSiaObjects(siaObjects []objects.SiaObject) (updated int64, err error) {
 	err = s.transaction(func(tx *txn) error {
+		updated = 0 // reset per transaction attempt
+
 		stmt, err := tx.Prepare(`
 			UPDATE objects SET sia_object = $1
 			WHERE sia_object_id = $2
@@ -277,6 +279,7 @@ func (s *Store) CopyObject(srcBucket, srcName, dstBucket, dstName string, meta m
 func (s *Store) ObjectParts(bucket, name string) ([]objects.Part, error) {
 	var parts []objects.Part
 	err := s.transaction(func(tx *txn) error {
+		parts = parts[:0] // reuse same slice if transaction retries
 		bid, err := bucketID(tx, bucket)
 		if err != nil {
 			return err
@@ -349,6 +352,7 @@ func (s *Store) AllFilenames() (filenames []string, err error) {
 // OrphanedObjects returns up to limit object IDs from the orphaned_objects table.
 func (s *Store) OrphanedObjects(limit int) (ids []types.Hash256, err error) {
 	err = s.transaction(func(tx *txn) error {
+		ids = ids[:0] // reuse same slice if transaction retries
 		rows, err := tx.Query("SELECT sia_object_id FROM orphaned_objects LIMIT $1", limit)
 		if err != nil {
 			return err
@@ -379,6 +383,7 @@ func (s *Store) RemoveOrphanedObject(objectID types.Hash256) error {
 func (s *Store) ObjectsForUpload() ([]objects.ObjectForUpload, error) {
 	var objs []objects.ObjectForUpload
 	if err := s.transaction(func(tx *txn) error {
+		objs = objs[:0] // reuse same slice if transaction retries
 		rows, err := tx.Query(`
 			SELECT b.name, o.name, o.filename, o.content_md5, o.size, EXISTS(SELECT 1 FROM object_parts p WHERE p.bucket_id = o.bucket_id AND p.name = o.name) AS has_parts
 			FROM objects o
@@ -524,10 +529,14 @@ func (s *Store) ListObjects(_ *string, bucket string, prefix s3.Prefix, page s3.
 
 	const maxObjsPerQuery = 100
 	err = s.transaction(func(tx *txn) error {
+		*result = *s3.NewObjectsListResult(page.MaxKeys) // reset per transaction attempt
+
 		bid, err := bucketID(tx, bucket)
 		if err != nil {
 			return fmt.Errorf("failed to get bucket ID: %w", err)
 		}
+
+		innerMarker := marker
 
 		list := func(marker *string) (string, string, error) {
 			query := `SELECT o.name, o.content_md5, o.size, o.updated_at
@@ -589,7 +598,6 @@ WHERE o.bucket_id = ?`
 			return lastMatchedPart, lastObj, nil
 		}
 
-		innerMarker := marker
 		for !result.IsTruncated {
 			lastMatchedPart, lastObj, err := list(innerMarker)
 			if err != nil {

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -227,6 +227,8 @@ func (s *Store) UpdateSiaObjects(siaObjects []objects.SiaObject) (updated int64,
 func (s *Store) CopyObject(srcBucket, srcName, dstBucket, dstName string, meta map[string]string, replace bool) (result *objects.Object, orphaned *string, err error) {
 	var obj objects.Object
 	err = s.transaction(func(tx *txn) error {
+		obj = objects.Object{} // reset per transaction attempt
+
 		srcBid, err := bucketID(tx, srcBucket)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes all instances where the transaction function body alters return params or outside variables in a way that breaks idempotency on retry, e.g. appending to a slice, or decrementing from a limit and so on. 

Closes https://github.com/SiaFoundation/s3d/issues/155