### PR TITLE
Include `StorageClass` in response

### DIFF
--- a/.changesets/storage-class-in-list-responses.md
+++ b/.changesets/storage-class-in-list-responses.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fixed StorageClass XML element missing from list object and list parts responses, restoring compatibility with S3 clients like Arq Backup that require it.

--- a/s3/messages.go
+++ b/s3/messages.go
@@ -122,7 +122,7 @@ type (
 		LastModified ContentTime  `xml:"LastModified"`
 		ETag         string       `xml:"ETag"`
 		Size         int64        `xml:"Size"`
-		StorageClass StorageClass `xml:"StorageClass,omitempty"`
+		StorageClass StorageClass `xml:"StorageClass"`
 		Owner        *UserInfo    `xml:"Owner,omitempty"`
 	}
 
@@ -350,7 +350,7 @@ type (
 		NextPartNumberMarker int                  `xml:"NextPartNumberMarker,omitempty"`
 		MaxParts             int64                `xml:"MaxParts"`
 		IsTruncated          bool                 `xml:"IsTruncated"`
-		StorageClass         StorageClass         `xml:"StorageClass,omitempty"`
+		StorageClass         StorageClass         `xml:"StorageClass"`
 		Initiator            *UserInfo            `xml:"Initiator,omitempty"`
 		Owner                *UserInfo            `xml:"Owner,omitempty"`
 		Parts                []ListedPartResponse `xml:"Part"`

--- a/s3/messages_test.go
+++ b/s3/messages_test.go
@@ -1,0 +1,32 @@
+package s3
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestStorageClassXML(t *testing.T) {
+	// verify that an empty StorageClass defaults to STANDARD
+	var sc StorageClass
+	buf, err := xml.Marshal(sc)
+	if err != nil {
+		t.Fatal(err)
+	} else if !strings.Contains(string(buf), "STANDARD") {
+		t.Fatalf("expected STANDARD, got %q", string(buf))
+	}
+
+	// verify that Content always includes StorageClass in XML output,
+	// this was a regression where omitempty caused the element to be
+	// absent breaking clients like Arq Backup
+	c := Content{
+		Key:  "test.txt",
+		Size: 1024,
+	}
+	buf, err = xml.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	} else if !strings.Contains(string(buf), "<StorageClass>STANDARD</StorageClass>") {
+		t.Fatalf("expected <StorageClass>STANDARD</StorageClass> in XML output, got %q", string(buf))
+	}
+}

--- a/s3/multipart_test.go
+++ b/s3/multipart_test.go
@@ -606,6 +606,8 @@ func TestListParts(t *testing.T) {
 		t.Fatal("expected untruncated response")
 	} else if res.MaxParts == nil || *res.MaxParts != 1000 {
 		t.Fatalf("expected default max parts 1000, got %v", res.MaxParts)
+	} else if res.StorageClass != types.StorageClassStandard {
+		t.Fatalf("expected storage class STANDARD, got %q", res.StorageClass)
 	}
 
 	for i, got := range res.Parts {

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -678,6 +678,8 @@ func TestListObjects(t *testing.T) {
 						t.Fatalf("expected object %v, got %v", tc.objects[i], *resp.Contents[i].Key)
 					} else if *resp.Contents[i].ETag != etag {
 						t.Fatalf("expected ETag %q, got %q", etag, *resp.Contents[i].ETag)
+					} else if resp.Contents[i].StorageClass != types.ObjectStorageClassStandard {
+						t.Fatalf("expected StorageClass STANDARD, got %q", resp.Contents[i].StorageClass)
 					}
 				}
 				assertCommonPrefixesEqual(t, tc.commonPrefixes, resp.CommonPrefixes)
@@ -701,6 +703,8 @@ func TestListObjects(t *testing.T) {
 						t.Fatalf("expected object %v, got %v", tc.objects[i], *resp.Contents[i].Key)
 					} else if *resp.Contents[i].ETag != etag {
 						t.Fatalf("expected ETag %q, got %q", etag, *resp.Contents[i].ETag)
+					} else if resp.Contents[i].StorageClass != types.ObjectStorageClassStandard {
+						t.Fatalf("expected StorageClass STANDARD, got %q", resp.Contents[i].StorageClass)
 					}
 				}
 				assertCommonPrefixesEqual(t, tc.commonPrefixes, resp.CommonPrefixes)


### PR DESCRIPTION
Turns out we can't `omitempty` the `StorageClass` property, clients like Arq trip over it. After making this change I was able to successfully complete a backup using Arq