### PR TITLE
Fix etags on multipart uploads

### DIFF
--- a/internal/testutil/backend.go
+++ b/internal/testutil/backend.go
@@ -141,6 +141,7 @@ func (b *MemoryBackend) CopyObject(ctx context.Context, accessKeyID, srcBucket, 
 		ContentMD5:   dstObjct.contentMD5,
 		LastModified: dstObjct.lastModified,
 		VersionID:    "", // versioning isn't supported
+		PartsCount:   int32(len(dstObjct.parts)),
 	}, nil
 }
 
@@ -300,7 +301,7 @@ func (b *MemoryBackend) ListObjects(ctx context.Context, accessKeyID *string, bu
 			result.Add(&s3.Content{
 				Key:          obj.name,
 				LastModified: s3.NewContentTime(obj.lastModified),
-				ETag:         s3.FormatETag(obj.contentMD5[:], 0),
+				ETag:         s3.FormatETag(obj.contentMD5[:], len(obj.parts)),
 				Owner:        owner,
 				Size:         int64(len(obj.data)),
 			})
@@ -804,6 +805,10 @@ func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, 
 		}
 	} else {
 		contentMD5 = obj.contentMD5
+		if len(obj.parts) > 0 {
+			pc := int32(len(obj.parts))
+			partCount = &pc
+		}
 	}
 
 	var body io.ReadCloser
@@ -831,7 +836,7 @@ func (b *MemoryBackend) headOrGetObject(_ context.Context, accessKeyID *string, 
 // is transmitted in http.TimeFormat which is truncated to seconds as well.
 func (o object) matches(oid s3.ObjectID) bool {
 	return o.name == oid.Key &&
-		(oid.ETag == nil || s3.FormatETag(o.contentMD5[:], 0) == *oid.ETag) &&
+		(oid.ETag == nil || s3.FormatETag(o.contentMD5[:], len(o.parts)) == *oid.ETag) &&
 		(oid.Size == nil || int64(len(o.data)) == *oid.Size) &&
 		(oid.LastModifiedTime == nil || o.lastModified.Equal(oid.LastModifiedTime.StdTime()))
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -94,12 +93,8 @@ func (t *S3Tester) CopyObject(ctx context.Context, srcBucket, srcObject, dstBuck
 	if err != nil {
 		return nil, err
 	}
-	etag := strings.Trim(*resp.CopyObjectResult.ETag, `"`)
-	hash, err := hex.DecodeString(etag)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.CopyObjectResult.ETag, err)
-	}
-	return hash, nil
+	hash := s3.ParseETag(*resp.CopyObjectResult.ETag)
+	return hash[:], nil
 }
 
 // CreateBucket creates a new S3 bucket.
@@ -151,12 +146,7 @@ func (t *S3Tester) GetObject(ctx context.Context, bucket, object string, rnge *s
 	if err != nil {
 		return nil, err
 	}
-	etag := strings.Trim(*resp.ETag, `"`)
-	var contentMD5 [16]byte
-	_, err = hex.Decode(contentMD5[:], []byte(etag))
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
-	}
+	contentMD5 := s3.ParseETag(*resp.ETag)
 	var objRange *s3.ObjectRange
 	var size int64
 	if resp.ContentRange != nil {
@@ -189,12 +179,7 @@ func (t *S3Tester) GetObjectPart(ctx context.Context, bucket, object string, par
 	if err != nil {
 		return nil, err
 	}
-	etag := strings.Trim(*resp.ETag, `"`)
-	var contentMD5 [16]byte
-	_, err = hex.Decode(contentMD5[:], []byte(etag))
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
-	}
+	contentMD5 := s3.ParseETag(*resp.ETag)
 	var objRange *s3.ObjectRange
 	var size int64
 	if resp.ContentRange != nil {
@@ -234,12 +219,7 @@ func (t *S3Tester) HeadObject(ctx context.Context, bucket, object string, rnge *
 	if err != nil {
 		return nil, err
 	}
-	etag := strings.Trim(*resp.ETag, `"`)
-	var contentMD5 [16]byte
-	_, err = hex.Decode(contentMD5[:], []byte(etag))
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
-	}
+	contentMD5 := s3.ParseETag(*resp.ETag)
 	var objRange *s3.ObjectRange
 	var size int64
 	if resp.ContentRange != nil {
@@ -271,12 +251,7 @@ func (t *S3Tester) HeadObjectPart(ctx context.Context, bucket, object string, pa
 	if err != nil {
 		return nil, err
 	}
-	etag := strings.Trim(*resp.ETag, `"`)
-	var contentMD5 [16]byte
-	_, err = hex.Decode(contentMD5[:], []byte(etag))
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
-	}
+	contentMD5 := s3.ParseETag(*resp.ETag)
 	var objRange *s3.ObjectRange
 	var size int64
 	if resp.ContentRange != nil {
@@ -385,12 +360,8 @@ func (t *S3Tester) PutObject(ctx context.Context, bucket, object string, r io.Re
 	if err != nil {
 		return nil, err
 	}
-	etag := strings.Trim(*resp.ETag, `"`)
-	hash, err := hex.DecodeString(etag)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode ETag %q: %w", *resp.ETag, err)
-	}
-	return hash, nil
+	hash := s3.ParseETag(*resp.ETag)
+	return hash[:], nil
 }
 
 // CreateMultipartUpload is a convenience wrapper around the AWS SDK's

--- a/s3/multipart_test.go
+++ b/s3/multipart_test.go
@@ -404,6 +404,20 @@ func TestCompleteMultipartUpload(t *testing.T) {
 		t.Fatalf("unexpected object data")
 	}
 
+	// regression: GET/HEAD without partNumber must return the multipart
+	// ETag with the "-N" suffix so clients don't mistake it for a plain MD5.
+	headResp, err := s3Tester.Client().HeadObject(t.Context(), &service.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(object),
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if !strings.Contains(*headResp.ETag, "-") {
+		t.Fatalf("expected multipart ETag suffix, got %q", *headResp.ETag)
+	} else if *headResp.ETag != expectedETag {
+		t.Fatalf("expected HEAD ETag %q, got %q", expectedETag, *headResp.ETag)
+	}
+
 	// assert [s3errs.ErrNoSuchUpload] is returned for invalid upload id
 	_, err = s3Tester.CompleteMultipartUpload(t.Context(), bucket, object, s3.NewUploadID().String(), parts)
 	testutil.AssertS3Error(t, s3errs.ErrNoSuchUpload, err)

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -957,7 +957,7 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 	}
 
 	var partsCount int
-	if obj.PartsCount != nil {
+	if obj.PartsCount != nil && r.URL.Query().Get("partNumber") == "" {
 		partsCount = int(*obj.PartsCount)
 	}
 	etag := FormatETag(obj.ContentMD5[:], partsCount)

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -39,6 +39,7 @@ type CopyObjectResult struct {
 	ContentMD5   [16]byte
 	LastModified time.Time
 	VersionID    string
+	PartsCount   int32
 }
 
 // DeleteObjectResult contains information about the result of a DeleteObject
@@ -179,7 +180,11 @@ func (s *s3) copyObject(w http.ResponseWriter, r *http.Request, accessKeyID, dst
 		if err != nil {
 			return err
 		}
-		etag := FormatETag(obj.ContentMD5[:], 0)
+		var partsCount int
+		if obj.PartsCount != nil {
+			partsCount = int(*obj.PartsCount)
+		}
+		etag := FormatETag(obj.ContentMD5[:], partsCount)
 		if ifMatch != "" && ifMatch != etag {
 			return s3errs.ErrPreconditionFailed
 		}
@@ -198,7 +203,7 @@ func (s *s3) copyObject(w http.ResponseWriter, r *http.Request, accessKeyID, dst
 		w.Header().Set("x-amz-version-id", string(result.VersionID))
 	}
 
-	etag := FormatETag(result.ContentMD5[:], 0)
+	etag := FormatETag(result.ContentMD5[:], int(result.PartsCount))
 	w.Header().Set("ETag", etag)
 	return writeXMLResponse(w, ObjectCopyResult{
 		ETag:         etag,
@@ -647,7 +652,7 @@ func (s *s3) putObject(w http.ResponseWriter, r *http.Request, accessKeyID strin
 
 // FormatETag formats the given hash as an S3 ETag string.
 func FormatETag(hash []byte, partsCount int) string {
-	if partsCount > 1 {
+	if partsCount > 0 {
 		return `"` + hex.EncodeToString(hash) + "-" + strconv.Itoa(partsCount) + `"`
 	}
 	return `"` + hex.EncodeToString(hash) + `"`
@@ -951,7 +956,11 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	etag := FormatETag(obj.ContentMD5[:], 0)
+	var partsCount int
+	if obj.PartsCount != nil {
+		partsCount = int(*obj.PartsCount)
+	}
+	etag := FormatETag(obj.ContentMD5[:], partsCount)
 	w.Header().Set("ETag", etag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(http.TimeFormat))
 
@@ -959,7 +968,7 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 		return s3errs.ErrNotModified
 	}
 
-	if obj.PartsCount != nil {
+	if obj.PartsCount != nil && r.URL.Query().Get("partNumber") != "" {
 		w.Header().Set("x-amz-mp-parts-count", fmt.Sprintf("%d", *obj.PartsCount))
 	}
 

--- a/sia/multipart_test.go
+++ b/sia/multipart_test.go
@@ -141,7 +141,7 @@ func TestMultipartAddPart(t *testing.T) {
 	res2, err := s3Tester.UploadPart(t.Context(), bucket, object, uploadID, 1, part)
 	if err != nil {
 		t.Fatal(err)
-	} else if res2 == nil || res2.ETag == nil || *res2.ETag != s3.FormatETag(md5Sum[:], 1) {
+	} else if res2 == nil || res2.ETag == nil || *res2.ETag != s3.FormatETag(md5Sum[:], 0) {
 		t.Fatalf("unexpected upload part result: %+v", res2)
 	}
 	// assert [s3errs.ErrNoSuchBucket] for missing bucket
@@ -172,7 +172,7 @@ func TestMultipartAddPart(t *testing.T) {
 	res3, err := s3Tester.UploadPart(t.Context(), bucket, object, uploadID, 1, part)
 	if err != nil {
 		t.Fatal(err)
-	} else if res3 == nil || res3.ETag == nil || *res3.ETag != s3.FormatETag(md5Sum[:], 1) {
+	} else if res3 == nil || res3.ETag == nil || *res3.ETag != s3.FormatETag(md5Sum[:], 0) {
 		t.Fatalf("unexpected upload part result: %+v", res3)
 	}
 
@@ -264,7 +264,7 @@ func TestMultipartListParts(t *testing.T) {
 		res, err := s3Tester.UploadPart(t.Context(), bucket, object, uploadID, int32(i+1), data)
 		if err != nil {
 			t.Fatal(err)
-		} else if res == nil || res.ETag == nil || *res.ETag != s3.FormatETag(md5Sum[:], 1) {
+		} else if res == nil || res.ETag == nil || *res.ETag != s3.FormatETag(md5Sum[:], 0) {
 			t.Fatalf("unexpected upload part result: %+v", res)
 		}
 		etags[i] = *res.ETag
@@ -660,8 +660,8 @@ func TestMultipartUploadPartCopy(t *testing.T) {
 	// assert ETag matches the copied data
 	expectedData := srcData[rnge.Start : rnge.Start+rnge.Length]
 	expectedMD5 := md5.Sum(expectedData)
-	if got := *res.CopyPartResult.ETag; got != s3.FormatETag(expectedMD5[:], 1) {
-		t.Fatalf("expected ETag %q, got %q", s3.FormatETag(expectedMD5[:], 1), got)
+	if got := *res.CopyPartResult.ETag; got != s3.FormatETag(expectedMD5[:], 0) {
+		t.Fatalf("expected ETag %q, got %q", s3.FormatETag(expectedMD5[:], 0), got)
 	}
 
 	// verify part is written to disk with the expected contents

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -160,6 +160,7 @@ func (s *Sia) CopyObject(ctx context.Context, accessKeyID, srcBucket, srcObject,
 		ContentMD5:   obj.ContentMD5,
 		LastModified: obj.LastModified,
 		VersionID:    "", // versioning isn't supported
+		PartsCount:   obj.PartsCount,
 	}, nil
 }
 
@@ -251,6 +252,10 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 		if err != nil {
 			return nil, err
 		}
+		var partsCount *int32
+		if obj.PartsCount > 0 {
+			partsCount = aws.Int32(obj.PartsCount)
+		}
 		resp = &s3.Object{
 			Body:         nil,
 			ContentMD5:   obj.ContentMD5,
@@ -258,7 +263,7 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 			Metadata:     obj.Meta,
 			Range:        rnge,
 			Size:         obj.Length,
-			PartsCount:   nil,
+			PartsCount:   partsCount,
 		}
 	}
 

--- a/sia/persist/sqlite/init.sql
+++ b/sia/persist/sqlite/init.sql
@@ -16,6 +16,7 @@ CREATE TABLE objects (
     content_md5 BLOB NOT NULL,
     metadata TEXT NOT NULL,
     size INTEGER NOT NULL,
+    parts_count INTEGER NOT NULL DEFAULT 0,
     updated_at INTEGER NOT NULL,
     filename TEXT, -- name of file for regular uploads or dir for multipart uploads
     sia_object_id BLOB,

--- a/sia/persist/sqlite/migrations.go
+++ b/sia/persist/sqlite/migrations.go
@@ -16,4 +16,12 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 		_, err := tx.Exec(`ALTER TABLE global_settings ADD COLUMN indexer_url TEXT;`)
 		return err
 	},
+	func(tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(`ALTER TABLE objects ADD COLUMN parts_count INTEGER NOT NULL DEFAULT 0`)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(`UPDATE objects SET parts_count = (SELECT COUNT(*) FROM object_parts WHERE object_parts.bucket_id = objects.bucket_id AND object_parts.name = objects.name)`)
+		return err
+	},
 }

--- a/sia/persist/sqlite/multipart.go
+++ b/sia/persist/sqlite/multipart.go
@@ -100,11 +100,11 @@ func (s *Store) CompleteMultipartUpload(bucket, name string, uploadID s3.UploadI
 		// the upload_id serves as the filename since parts are stored
 		// under the upload directory
 		_, err = tx.Exec(`
-			INSERT INTO objects (bucket_id, name, content_md5, metadata, size, updated_at, filename)
-			SELECT bucket_id, name, $1, metadata, $2, $3, $4
+			INSERT INTO objects (bucket_id, name, content_md5, metadata, size, parts_count, updated_at, filename)
+			SELECT bucket_id, name, $1, metadata, $2, $3, $4, $5
 			FROM multipart_uploads
-			WHERE upload_id = $5
-		`, sqlMD5(contentMD5), contentLength, sqlTime(time.Now()), uploadID.String(), sqlUploadID(uploadID))
+			WHERE upload_id = $6
+		`, sqlMD5(contentMD5), contentLength, partCount, sqlTime(time.Now()), uploadID.String(), sqlUploadID(uploadID))
 		if err != nil {
 			return err
 		}

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -85,10 +85,10 @@ func (s *Store) GetObject(accessKeyID *string, bucket, name string, partNumber *
 }
 
 func getObject(tx *txn, obj *objects.Object, bid int64, name string, partNumber *int32) error {
-	// get parts count
+	// get parts count from the objects table
 	err := tx.QueryRow(`
-		SELECT COUNT(*)
-		FROM object_parts
+		SELECT parts_count
+		FROM objects
 		WHERE bucket_id = $1 AND name = $2
 	`, bid, name).Scan(&obj.PartsCount)
 	if err != nil {
@@ -152,7 +152,7 @@ func (s *Store) PutObject(accessKeyID, bucket, name string, contentMD5 [16]byte,
 		if err != nil {
 			return err
 		}
-		orphaned, err = putObject(tx, bid, name, contentMD5, meta, length, fileName, nil)
+		orphaned, err = putObject(tx, bid, name, contentMD5, meta, length, 0, fileName, nil)
 		return err
 	})
 	return orphaned, err
@@ -265,7 +265,7 @@ func (s *Store) CopyObject(srcBucket, srcName, dstBucket, dstName string, meta m
 			return err
 		}
 
-		orphaned, err = putObject(tx, dstBid, dstName, obj.ContentMD5, obj.Meta, obj.Length, obj.FileName, obj.SiaObject)
+		orphaned, err = putObject(tx, dstBid, dstName, obj.ContentMD5, obj.Meta, obj.Length, obj.PartsCount, obj.FileName, obj.SiaObject)
 		return err
 	})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -387,7 +387,7 @@ func (s *Store) ObjectsForUpload() ([]objects.ObjectForUpload, error) {
 	if err := s.transaction(func(tx *txn) error {
 		objs = objs[:0] // reuse same slice if transaction retries
 		rows, err := tx.Query(`
-			SELECT b.name, o.name, o.filename, o.content_md5, o.size, EXISTS(SELECT 1 FROM object_parts p WHERE p.bucket_id = o.bucket_id AND p.name = o.name) AS has_parts
+			SELECT b.name, o.name, o.filename, o.content_md5, o.size, o.parts_count > 0 AS has_parts
 			FROM objects o
 			JOIN buckets b ON b.id = o.bucket_id
 			WHERE o.filename IS NOT NULL
@@ -416,7 +416,7 @@ func (s *Store) ObjectsForUpload() ([]objects.ObjectForUpload, error) {
 // prior row is deleted first. If the prior row's sia_object_id is no longer
 // referenced, it is added to orphaned_objects. If the prior row's filename is
 // no longer referenced, it is returned for cleanup.
-func putObject(tx *txn, bid int64, name string, contentMD5 [16]byte, meta map[string]string, length int64, fileName *string, siaObject *objects.SiaObject) (*string, error) {
+func putObject(tx *txn, bid int64, name string, contentMD5 [16]byte, meta map[string]string, length int64, partsCount int32, fileName *string, siaObject *objects.SiaObject) (*string, error) {
 	if meta == nil {
 		meta = make(map[string]string) // force '{}' instead of 'null' in JSON
 	}
@@ -434,10 +434,10 @@ func putObject(tx *txn, bid int64, name string, contentMD5 [16]byte, meta map[st
 	}
 
 	_, err = tx.Exec(`
-		INSERT INTO objects (bucket_id, name, sia_object_id, content_md5, metadata, size, updated_at, filename, sia_object)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO objects (bucket_id, name, sia_object_id, content_md5, metadata, size, parts_count, updated_at, filename, sia_object)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 	`, bid, name, id, sqlMD5(contentMD5),
-		sqlMetaJSON(meta), length, sqlTime(time.Now()),
+		sqlMetaJSON(meta), length, partsCount, sqlTime(time.Now()),
 		fileName, sealed)
 	if err != nil {
 		return nil, err
@@ -541,7 +541,7 @@ func (s *Store) ListObjects(_ *string, bucket string, prefix s3.Prefix, page s3.
 		innerMarker := marker
 
 		list := func(marker *string) (string, string, error) {
-			query := `SELECT o.name, o.content_md5, o.size, o.updated_at
+			query := `SELECT o.name, o.content_md5, o.size, o.parts_count, o.updated_at
 FROM objects o
 WHERE o.bucket_id = ?`
 			args := []any{bid}
@@ -573,6 +573,7 @@ WHERE o.bucket_id = ?`
 					&obj.Name,
 					(*sqlMD5)(&obj.ContentMD5),
 					&obj.Length,
+					&obj.PartsCount,
 					(*sqlTime)(&obj.LastModified),
 				)
 				if err != nil {
@@ -587,7 +588,7 @@ WHERE o.bucket_id = ?`
 					result.Add(&s3.Content{
 						Key:          obj.Name,
 						LastModified: s3.NewContentTime(obj.LastModified),
-						ETag:         s3.FormatETag(obj.ContentMD5[:], 0),
+						ETag:         s3.FormatETag(obj.ContentMD5[:], int(obj.PartsCount)),
 						Size:         int64(obj.Length),
 						Owner:        owner,
 					})

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -266,7 +266,22 @@ func (s *Store) CopyObject(srcBucket, srcName, dstBucket, dstName string, meta m
 		}
 
 		orphaned, err = putObject(tx, dstBid, dstName, obj.ContentMD5, obj.Meta, obj.Length, obj.PartsCount, obj.FileName, obj.SiaObject)
-		return err
+		if err != nil {
+			return err
+		}
+
+		if obj.PartsCount > 0 {
+			_, err = tx.Exec(`
+				INSERT INTO object_parts (bucket_id, name, part_number, filename, content_md5, content_length, offset)
+				SELECT $1, $2, part_number, filename, content_md5, content_length, offset
+				FROM object_parts
+				WHERE bucket_id = $3 AND name = $4
+			`, dstBid, dstName, srcBid, srcName)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil, s3errs.ErrNoSuchKey


### PR DESCRIPTION
Reproduce:

```
.config/rclone/rclone.conf:
[s3d]
type = s3
provider = Other
access_key_id = xxxxxx
secret_access_key = xxxxxxx
endpoint = http://127.0.0.1:8000
force_path_style = true
no_check_bucket = true
```

```
$ dd if=/dev/urandom of=/tmp/repro.bin bs=1M count=12
$ aws s3api create-bucket --endpoint-url http://127.0.0.1:8000 --bucket repro
$ aws s3 cp --endpoint-url http://127.0.0.1:8000 /tmp/repro.bin s3://repro/multi.bin

$ rclone copyto s3d:repro/multi.bin /tmp/dl.bin
2026/05/22 14:25:45 ERROR : dl.bin.e12bd82d.partial: corrupted on transfer: md5 hashes differ src(S3 bucket repro) "81c8bd8d557d005cf831b1e4b0bd253b" vs dst(Local file system at /tmp) "a7b61a7edde714c3dafd90d56833a156"
2026/05/22 14:25:45 ERROR : Attempt 1/3 failed with 1 errors and: corrupted on transfer: md5 hashes differ src(S3 bucket repro) "81c8bd8d557d005cf831b1e4b0bd253b" vs dst(Local file system at /tmp) "a7b61a7edde714c3dafd90d56833a156"
2026/05/22 14:25:45 ERROR : dl.bin.e12bd82d.partial: corrupted on transfer: md5 hashes differ src(S3 bucket repro) "81c8bd8d557d005cf831b1e4b0bd253b" vs dst(Local file system at /tmp) "a7b61a7edde714c3dafd90d56833a156"
2026/05/22 14:25:45 ERROR : Attempt 2/3 failed with 1 errors and: corrupted on transfer: md5 hashes differ src(S3 bucket repro) "81c8bd8d557d005cf831b1e4b0bd253b" vs dst(Local file system at /tmp) "a7b61a7edde714c3dafd90d56833a156"
2026/05/22 14:25:45 ERROR : dl.bin.e12bd82d.partial: corrupted on transfer: md5 hashes differ src(S3 bucket repro) "81c8bd8d557d005cf831b1e4b0bd253b" vs dst(Local file system at /tmp) "a7b61a7edde714c3dafd90d56833a156"
2026/05/22 14:25:45 ERROR : Attempt 3/3 failed with 1 errors and: corrupted on transfer: md5 hashes differ src(S3 bucket repro) "81c8bd8d557d005cf831b1e4b0bd253b" vs dst(Local file system at /tmp) "a7b61a7edde714c3dafd90d56833a156"
2026/05/22 14:25:45 NOTICE: Failed to copyto: corrupted on transfer: md5 hashes differ src(S3 bucket repro) "81c8bd8d557d005cf831b1e4b0bd253b" vs dst(Local file system at /tmp) "a7b61a7edde714c3dafd90d56833a156"
```
