### PR TITLE
Support arbitrary delimiters in ListObjects

### DIFF
--- a/s3/objects.go
+++ b/s3/objects.go
@@ -456,10 +456,6 @@ func (s *s3) listObjectsV1(w http.ResponseWriter, r *http.Request, accessKeyID *
 		page.Marker = &marker
 	}
 
-	if prefix.Delimiter != "" && prefix.Delimiter != "/" {
-		return s3errs.ErrNotImplemented // only "/" delimiter is supported
-	}
-
 	// list objects
 	objects, err := s.backend.ListObjects(r.Context(), accessKeyID, bucket, prefix, page)
 	if err != nil {
@@ -505,8 +501,6 @@ func (s *s3) listObjectsV2(w http.ResponseWriter, r *http.Request, accessKeyID *
 	page, err := listObjectsPageFromQuery(q)
 	if err != nil {
 		return err
-	} else if prefix.Delimiter != "" && prefix.Delimiter != "/" {
-		return s3errs.ErrNotImplemented // only "/" delimiter is supported
 	}
 
 	// don't allow unordered listing with delimiter

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -658,6 +658,12 @@ func TestListObjects(t *testing.T) {
 			objects:        []string{"foo"},
 			commonPrefixes: []string{"foo/"},
 		},
+		{
+			name:           "NonSlashDelimiter",
+			delimiter:      ptr("b"),
+			objects:        []string{"foo"},
+			commonPrefixes: []string{"foo/b"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sia/persist/sqlite/objects_test.go
+++ b/sia/persist/sqlite/objects_test.go
@@ -760,57 +760,57 @@ func BenchmarkListObjects(b *testing.B) {
 	}
 	b.Cleanup(func() { store.Close() })
 
-	// prepare a bucket
-	bucket := "foo"
-	if err := store.CreateBucket("", bucket); err != nil {
-		b.Fatal(err)
-	}
-
 	obj := sdk.Object{}
 	sealed := obj.Seal(types.GeneratePrivateKey())
+	objID := sealed.ID()
+	contentMD5 := [16]byte(frand.Bytes(16))
 
-	err = store.transaction(func(tx *txn) error {
-		bid, err := bucketID(tx, bucket)
-		if err != nil {
-			return err
+	var size uint64
+	for _, slab := range sealed.Slabs {
+		size += uint64(slab.Length)
+	}
+
+	populateBucket := func(bucket, delimiter string) {
+		if err := store.CreateBucket("", bucket); err != nil {
+			b.Fatal(err)
 		}
+		err := store.transaction(func(tx *txn) error {
+			bid, err := bucketID(tx, bucket)
+			if err != nil {
+				return err
+			}
+			now := time.Now()
+			for i := 0; i < dir1; i++ {
+				layer1 := fmt.Sprint(i)
+				for j := 0; j < dir2; j++ {
+					layer2 := layer1 + delimiter + fmt.Sprint(j)
+					for k := 0; k < dir3; k++ {
+						layer3 := layer2 + delimiter + fmt.Sprint(k)
+						for l := 0; l < dir4; l++ {
+							idx := i*dir1 + j*dir2 + k*dir3 + l*dir4
+							if (idx % 10000) == 0 {
+								b.Log(idx)
+							}
 
-		objID := sealed.ID()
-		contentMD5 := [16]byte(frand.Bytes(16))
+							name := strconv.Itoa(idx)
+							key := layer3 + delimiter + name
 
-		var size uint64
-		for _, slab := range sealed.Slabs {
-			size += uint64(slab.Length)
-		}
-
-		now := time.Now()
-		for i := 0; i < dir1; i++ {
-			layer1 := fmt.Sprint(i)
-			for j := 0; j < dir2; j++ {
-				layer2 := filepath.Join(layer1, fmt.Sprint(j))
-				for k := 0; k < dir3; k++ {
-					layer3 := filepath.Join(layer2, fmt.Sprint(k))
-					for l := 0; l < dir4; l++ {
-						idx := i*dir1 + j*dir2 + k*dir3 + l*dir4
-						if (idx % 10000) == 0 {
-							b.Log(idx)
-						}
-
-						name := strconv.Itoa(idx)
-						layer4 := filepath.Join(layer3, name)
-
-						_, err = tx.Exec(`
+							_, err = tx.Exec(`
 			INSERT INTO objects (bucket_id, name, sia_object_id, content_md5, metadata, size, updated_at, sia_object)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, bid, layer4, sqlHash256(objID), sqlMD5(contentMD5), []byte{}, size, sqlTime(now), sqlSiaObject(sealed))
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, bid, key, sqlHash256(objID), sqlMD5(contentMD5), []byte{}, size, sqlTime(now), sqlSiaObject(sealed))
+						}
 					}
 				}
 			}
+			return err
+		})
+		if err != nil {
+			b.Fatal(err)
 		}
-		return err
-	})
-	if err != nil {
-		b.Fatal(err)
 	}
+
+	populateBucket("slash", "/")
+	populateBucket("backslash", `\`)
 
 	if _, err := store.db.Exec(`VACUUM;`); err != nil {
 		b.Fatal(err)
@@ -819,9 +819,10 @@ func BenchmarkListObjects(b *testing.B) {
 	}
 
 	const maxKeys = 1000
+
 	b.Run("no_delimiter_no_prefix", func(b *testing.B) {
 		for b.Loop() {
-			result, err := store.ListObjects(nil, bucket, s3.Prefix{}, s3.ListObjectsPage{MaxKeys: maxKeys})
+			result, err := store.ListObjects(nil, "slash", s3.Prefix{}, s3.ListObjectsPage{MaxKeys: maxKeys})
 			if err != nil {
 				b.Fatal(err)
 			} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
@@ -830,96 +831,105 @@ func BenchmarkListObjects(b *testing.B) {
 		}
 	})
 
-	b.Run("root_delimiter", func(b *testing.B) {
-		for b.Loop() {
-			var marker *string
-			for {
+	benchmarkListObjects := func(b *testing.B, bucket, delimiter string) {
+		b.Run("root_delimiter", func(b *testing.B) {
+			for b.Loop() {
+				var marker *string
+				for {
+					result, err := store.ListObjects(nil, bucket, s3.Prefix{
+						Delimiter:    delimiter,
+						HasDelimiter: true,
+					}, s3.ListObjectsPage{MaxKeys: maxKeys, Marker: marker})
+					if err != nil {
+						b.Fatal(err)
+					} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
+						b.Fatal("no results")
+					}
+					if !result.IsTruncated {
+						break
+					}
+					marker = &result.NextMarker
+				}
+			}
+		})
+
+		b.Run("random_without_delimiter", func(b *testing.B) {
+			for b.Loop() {
+				var prefix string
+				switch frand.Intn(3) {
+				case 0:
+					prefix = fmt.Sprintf("%d"+delimiter, frand.Intn(dir1))
+				case 1:
+					prefix = fmt.Sprintf("%d"+delimiter+"%d"+delimiter, frand.Intn(dir1), frand.Intn(dir2))
+				case 2:
+					prefix = fmt.Sprintf("%d"+delimiter+"%d"+delimiter+"%d"+delimiter, frand.Intn(dir1), frand.Intn(dir2), frand.Intn(dir3))
+				}
 				result, err := store.ListObjects(nil, bucket, s3.Prefix{
-					Delimiter:    "/",
-					HasDelimiter: true,
-				}, s3.ListObjectsPage{MaxKeys: maxKeys, Marker: marker})
+					Prefix:    prefix,
+					HasPrefix: true,
+				}, s3.ListObjectsPage{MaxKeys: maxKeys})
 				if err != nil {
 					b.Fatal(err)
 				} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
 					b.Fatal("no results")
 				}
-				if !result.IsTruncated {
-					break
+			}
+		})
+
+		b.Run("random_with_delimiter", func(b *testing.B) {
+			for b.Loop() {
+				result, err := store.ListObjects(nil, bucket, s3.Prefix{
+					Prefix:       fmt.Sprintf("%d"+delimiter+"%d"+delimiter, frand.Intn(dir1), frand.Intn(dir2)),
+					HasPrefix:    true,
+					Delimiter:    delimiter,
+					HasDelimiter: true,
+				}, s3.ListObjectsPage{MaxKeys: maxKeys})
+				if err != nil {
+					b.Fatal(err)
+				} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
+					b.Fatal("no results")
 				}
-				marker = &result.NextMarker
 			}
-		}
-	})
+		})
 
-	b.Run("random_without_delimiter", func(b *testing.B) {
-		for b.Loop() {
-			var prefix string
-			switch frand.Intn(3) {
-			case 0:
-				prefix = fmt.Sprintf("%d/", frand.Intn(dir1))
-			case 1:
-				prefix = fmt.Sprintf("%d/%d/", frand.Intn(dir1), frand.Intn(dir2))
-			case 2:
-				prefix = fmt.Sprintf("%d/%d/%d/", frand.Intn(dir1), frand.Intn(dir2), frand.Intn(dir3))
+		b.Run("folder_bottom_delimiter", func(b *testing.B) {
+			for b.Loop() {
+				result, err := store.ListObjects(nil, bucket, s3.Prefix{
+					Prefix:       "0" + delimiter + "0" + delimiter + "0",
+					HasPrefix:    true,
+					Delimiter:    delimiter,
+					HasDelimiter: true,
+				}, s3.ListObjectsPage{MaxKeys: maxKeys})
+				if err != nil {
+					b.Fatal(err)
+				} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
+					b.Fatal("no results")
+				}
 			}
-			result, err := store.ListObjects(nil, bucket, s3.Prefix{
-				Prefix:    prefix,
-				HasPrefix: true,
-			}, s3.ListObjectsPage{MaxKeys: maxKeys})
-			if err != nil {
-				b.Fatal(err)
-			} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
-				b.Fatal("no results")
-			}
-		}
-	})
+		})
 
-	b.Run("random_with_delimiter", func(b *testing.B) {
-		for b.Loop() {
-			result, err := store.ListObjects(nil, bucket, s3.Prefix{
-				Prefix:       fmt.Sprintf("%d/%d/", frand.Intn(dir1), frand.Intn(dir2)),
-				HasPrefix:    true,
-				Delimiter:    "/",
-				HasDelimiter: true,
-			}, s3.ListObjectsPage{MaxKeys: maxKeys})
-			if err != nil {
-				b.Fatal(err)
-			} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
-				b.Fatal("no results")
+		b.Run("folder_delimiter", func(b *testing.B) {
+			for b.Loop() {
+				result, err := store.ListObjects(nil, bucket, s3.Prefix{
+					Prefix:       "0" + delimiter,
+					HasPrefix:    true,
+					Delimiter:    delimiter,
+					HasDelimiter: true,
+				}, s3.ListObjectsPage{MaxKeys: maxKeys})
+				if err != nil {
+					b.Fatal(err)
+				} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
+					b.Fatal("no results")
+				}
 			}
-		}
-	})
+		})
+	}
 
-	b.Run("folder_bottom_delimiter", func(b *testing.B) {
-		for b.Loop() {
-			result, err := store.ListObjects(nil, bucket, s3.Prefix{
-				Prefix:       "0/0/0",
-				HasPrefix:    true,
-				Delimiter:    "/",
-				HasDelimiter: true,
-			}, s3.ListObjectsPage{MaxKeys: maxKeys})
-			if err != nil {
-				b.Fatal(err)
-			} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
-				b.Fatal("no results")
-			}
-		}
+	b.Run("slash", func(b *testing.B) {
+		benchmarkListObjects(b, "slash", "/")
 	})
-
-	b.Run("folder_delimiter", func(b *testing.B) {
-		for b.Loop() {
-			result, err := store.ListObjects(nil, bucket, s3.Prefix{
-				Prefix:       "0/",
-				HasPrefix:    true,
-				Delimiter:    "/",
-				HasDelimiter: true,
-			}, s3.ListObjectsPage{MaxKeys: maxKeys})
-			if err != nil {
-				b.Fatal(err)
-			} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
-				b.Fatal("no results")
-			}
-		}
+	b.Run("backslash", func(b *testing.B) {
+		benchmarkListObjects(b, "backslash", `\`)
 	})
 }
 

--- a/tox/tox_test.go
+++ b/tox/tox_test.go
@@ -134,13 +134,11 @@ func TestS3(t *testing.T) {
 	// we ignore the following tests
 	//  - tests marked s3d_not_implemented or s3d_not_supported since they
 	//    cover features s3d does not handle by design
-	//  - tests marked s3d_not_delimiter_alt since s3d only supports "/"
-	//    as a delimiter
 	//  - bucket_logging tests since s3d does not implement bucket logging
 	t.Run("test_s3", func(t *testing.T) {
 		runTox(t, confPath, testsDir,
 			"s3tests/functional/test_s3.py",
-			"-m", "(copy or delete or list_objects or multipart) and not s3d_not_implemented and not s3d_not_supported and not s3d_not_delimiter_alt and not bucket_logging",
+			"-m", "(copy or delete or list_objects or multipart) and not s3d_not_implemented and not s3d_not_supported and not bucket_logging",
 		)
 	})
 


### PR DESCRIPTION
Close #169

```
goos: linux
goarch: amd64
pkg: github.com/SiaFoundation/s3d/sia/persist/sqlite
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkListObjects/no_delimiter_no_prefix-4                286           3916291 ns/op
BenchmarkListObjects/slash/root_delimiter-4                   20          52887625 ns/op
BenchmarkListObjects/slash/random_without_delimiter-4        816           1515163 ns/op
BenchmarkListObjects/slash/random_with_delimiter-4          1434            769890 ns/op
BenchmarkListObjects/slash/folder_bottom_delimiter-4        8109            166300 ns/op
BenchmarkListObjects/slash/folder_delimiter-4               1570            766823 ns/op
BenchmarkListObjects/backslash/root_delimiter-4               19          54393207 ns/op
BenchmarkListObjects/backslash/random_without_delimiter-4                    850           1631373 ns/op
BenchmarkListObjects/backslash/random_with_delimiter-4                      1550            786753 ns/op
BenchmarkListObjects/backslash/folder_bottom_delimiter-4                    7903            164151 ns/op
BenchmarkListObjects/backslash/folder_delimiter-4                           1610            740688 ns/op
PASS
ok      github.com/SiaFoundation/s3d/sia/persist/sqlite 80.354s
```