### PR TITLE
Minor fixes

### DIFF
--- a/s3/messages.go
+++ b/s3/messages.go
@@ -58,7 +58,7 @@ func NewContentTime(t time.Time) ContentTime {
 func (c ContentTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	// This is the format expected by the aws xml code, not the default.
 	if !c.IsZero() {
-		var s = c.UTC().Format("2006-01-02T15:04:05.999Z")
+		var s = c.UTC().Format("2006-01-02T15:04:05.000Z")
 		return e.EncodeElement(s, start)
 	}
 	return nil

--- a/s3/messages_test.go
+++ b/s3/messages_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStorageClassXML(t *testing.T) {
@@ -28,5 +29,35 @@ func TestStorageClassXML(t *testing.T) {
 		t.Fatal(err)
 	} else if !strings.Contains(string(buf), "<StorageClass>STANDARD</StorageClass>") {
 		t.Fatalf("expected <StorageClass>STANDARD</StorageClass> in XML output, got %q", string(buf))
+	}
+}
+
+func TestContentTimeXML(t *testing.T) {
+	// Strict S3 client parsers (e.g. jets3t used by older Cyberduck) expect
+	// LastModified to always have exactly 3 fractional-second digits. Go's
+	// .999 format suppresses trailing zeros, so a whole-second time would
+	// previously render as "...43Z" and fail those parsers. Make sure the
+	// format always pads to .SSSZ.
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"whole second", time.Date(2026, 6, 1, 9, 1, 43, 0, time.UTC), "2026-06-01T09:01:43.000Z"},
+		{"half second", time.Date(2026, 6, 1, 9, 1, 43, 500*1000*1000, time.UTC), "2026-06-01T09:01:43.500Z"},
+		{"five ms", time.Date(2026, 6, 1, 9, 1, 43, 5*1000*1000, time.UTC), "2026-06-01T09:01:43.005Z"},
+		{"sub-ms truncates", time.Date(2026, 6, 1, 9, 1, 43, 123456789, time.UTC), "2026-06-01T09:01:43.123Z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, err := xml.Marshal(NewContentTime(tt.in))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "<ContentTime>" + tt.want + "</ContentTime>"
+			if string(buf) != want {
+				t.Fatalf("expected %q, got %q", want, string(buf))
+			}
+		})
 	}
 }

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -265,7 +266,7 @@ func (s *Sia) ProcessOrphans(ctx context.Context) {
 			default:
 			}
 
-			if err := s.sdk.DeleteObject(ctx, id); err != nil && !errors.Is(err, slabs.ErrObjectNotFound) {
+			if err := s.sdk.DeleteObject(ctx, id); err != nil && !strings.Contains(err.Error(), slabs.ErrObjectNotFound.Error()) {
 				s.logger.Error("failed to unpin object from indexer", zap.Error(err), zap.Stringer("objectID", &id))
 				return
 			}
@@ -273,6 +274,7 @@ func (s *Sia) ProcessOrphans(ctx context.Context) {
 				s.logger.Error("failed to remove orphaned object", zap.Error(err), zap.Stringer("objectID", &id))
 				return
 			}
+			s.logger.Debug("processed orphaned object", zap.Stringer("objectID", &id))
 			totalUnpinned++
 		}
 		if len(orphans) < batchSize {


### PR DESCRIPTION
This PR updates the format string for `ContentTime` to use `000Z` instead of `999Z` to make sure strict parsers don't fail. With `999Z` Go will omit the dot and 3 millisecond digits on whole-second timestamps. With `000Z` it always returns the full timestamp. 

The other one is the `slabs.ErrObjectNotFound` error that we can't check for with `errors.Is` since it is returned by an http API. 