### PR TITLE
Implicitly handle localhost as a host base

### DIFF
--- a/.changeset/correctly_handle_virtual_host_style_routing_without_a_port.md
+++ b/.changeset/correctly_handle_virtual_host_style_routing_without_a_port.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Correctly handle virtual host style routing without a port.

--- a/.changeset/implicily_handle_localhost_as_a_host_base.md
+++ b/.changeset/implicily_handle_localhost_as_a_host_base.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Implicily handle localhost as a host base.

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ log:
     format: json # log format (human, json)
     path: /var/log/s3d/s3d.log # log file path (defaults to <directory>/s3d.log)
 s3:
-  hostBases:
+  hostBases: # bases for virtual-hosted-style addressing ("localhost" is always included)
     - s3.example.com
 ```
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -596,7 +596,6 @@ func NewTester(t testing.TB, opts ...TesterOption) *S3Tester {
 	}
 
 	handler := s3.New(cfg.backend,
-		s3.WithHostBucketBases([]string{"localhost"}),
 		s3.WithLogger(zaptest.NewLogger(t)))
 
 	server := httptest.NewUnstartedServer(handler)

--- a/s3/multipart.go
+++ b/s3/multipart.go
@@ -530,7 +530,7 @@ func (s *s3) completeMultipartUpload(w http.ResponseWriter, r *http.Request, acc
 	}
 
 	var location string
-	if len(s.hostBucketBases) > 0 {
+	if _, ok := s.bucketFromHost(r.Host); ok {
 		location = fmt.Sprintf("%s://%s/%s", protocol, r.Host, object)
 	} else {
 		location = fmt.Sprintf("%s://%s/%s/%s", protocol, r.Host, bucket, object)

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -257,7 +258,8 @@ func WithLogger(logger *zap.Logger) Option {
 // WithHostBucketBases sets the host bucket bases for the S3 API handler.
 // e.g. if you run the handler on "s3.example.com", you would set the base to
 // "s3.example.com" to make sure that requests to "mybucket.s3.example.com" are
-// routed to the "mybucket" bucket.
+// routed to the "mybucket" bucket. "localhost" is always included as a base, so
+// virtual-hosted-style requests work out of the box on local setups.
 func WithHostBucketBases(bases []string) Option {
 	return func(s *s3) {
 		s.hostBucketBases = bases
@@ -283,13 +285,18 @@ func New(b Backend, opts ...Option) http.Handler {
 		opt(s3)
 	}
 
+	// "localhost" is reserved (RFC 6761) and should therefore never collide
+	// with a configured base, so it is always added to support
+	// virtual-hosted-style requests during local development.
+	if !slices.Contains(s3.hostBucketBases, "localhost") {
+		s3.hostBucketBases = append(s3.hostBucketBases, "localhost")
+	}
+
 	// base router
 	handler := auth.AuthenticatedHandler(auth.AuthenticatedHandlerFunc(s3.routeBase))
 
 	// handle virtual-hosted style bucket URLs
-	if len(s3.hostBucketBases) > 0 {
-		handler = s3.hostBucketBaseMiddleware(handler)
-	}
+	handler = s3.hostBucketBaseMiddleware(handler)
 
 	// wrap authentication in CORS so unauthenticated preflight requests are
 	// handled before they reach the authentication middleware
@@ -370,36 +377,34 @@ func (s s3) authMiddleware(handler auth.AuthenticatedHandler) http.Handler {
 	})
 }
 
-// hostBucketBaseMiddleware forces the server to use VirtualHost-style bucket URLs:
+// bucketFromHost returns the bucket name if the given host addresses a bucket
+// as a subdomain of one of the configured host bucket bases. The host may
+// contain a port.
+func (s *s3) bucketFromHost(host string) (bucket string, ok bool) {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	} // otherwise the host contains no port, e.g. behind a reverse proxy
+	// listening on 80/443
+
+	for _, base := range s.hostBucketBases {
+		suffix := "." + strings.Trim(base, ".")
+		if !strings.HasSuffix(host, suffix) {
+			continue
+		}
+		bucket = host[:len(host)-len(suffix)]
+		if bucket == "" || strings.IndexByte(bucket, '.') >= 0 {
+			continue
+		}
+		return bucket, true
+	}
+	return "", false
+}
+
+// hostBucketBaseMiddleware handles VirtualHost-style bucket URLs:
 // https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
 func (s *s3) hostBucketBaseMiddleware(handler auth.AuthenticatedHandler) auth.AuthenticatedHandler {
-	bases := make([]string, len(s.hostBucketBases))
-	for idx, base := range s.hostBucketBases {
-		bases[idx] = "." + strings.Trim(base, ".")
-	}
-
-	matchBucket := func(host string) (bucket string, ok bool) {
-		for _, base := range bases {
-			if !strings.HasSuffix(host, base) {
-				continue
-			}
-			bucket = host[:len(host)-len(base)]
-			if idx := strings.IndexByte(bucket, '.'); idx >= 0 {
-				continue
-			}
-			return bucket, true
-		}
-		return "", false
-	}
-
 	return auth.AuthenticatedHandlerFunc(func(w http.ResponseWriter, rq *http.Request, accessKeyID *string) {
-		host, _, err := net.SplitHostPort(rq.Host)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		bucket, ok := matchBucket(host)
+		bucket, ok := s.bucketFromHost(rq.Host)
 		if !ok {
 			handler.ServeHTTP(w, rq, accessKeyID)
 			return

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -2,17 +2,24 @@ package s3_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/SiaFoundation/s3d/internal/testutil"
 	"github.com/SiaFoundation/s3d/s3"
 	"github.com/SiaFoundation/s3d/s3/s3errs"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	service "github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.uber.org/zap/zaptest"
 )
 
 func newAdminServer(t *testing.T) (string, *http.Client) {
@@ -124,4 +131,69 @@ func TestAccessDenied(t *testing.T) {
 		_, err := s3.ListMultipartUploads(t.Context(), "bucket", nil)
 		return err
 	})
+}
+
+// TestHostBucketStyles verifies that path-style and virtual-hosted-style
+// requests both work, with and without a port in the Host header.
+// "localhost" is implicitly available as a host bucket base.
+func TestHostBucketStyles(t *testing.T) {
+	backend := testutil.NewBackend(t)
+	handler := s3.New(backend, s3.WithLogger(zaptest.NewLogger(t)))
+
+	signer := v4.NewSigner()
+	creds := aws.Credentials{
+		AccessKeyID:     testutil.AccessKeyID,
+		SecretAccessKey: testutil.SecretAccessKey,
+	}
+
+	do := func(t *testing.T, method, host, path, body string) *httptest.ResponseRecorder {
+		t.Helper()
+
+		req := httptest.NewRequest(method, "http://"+host+path, strings.NewReader(body))
+		req.Host = host
+		if body != "" {
+			req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		}
+		payloadHash := sha256.Sum256([]byte(body))
+		hashHex := hex.EncodeToString(payloadHash[:])
+		req.Header.Set("X-Amz-Content-Sha256", hashHex)
+		if err := signer.SignHTTP(t.Context(), creds, req, hashHex, "s3", "us-east-1", time.Now()); err != nil {
+			t.Fatal(err)
+		}
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// create a bucket containing an object using path-style requests
+	if rec := do(t, http.MethodPut, "localhost:8000", "/bucket", ""); rec.Code != http.StatusOK {
+		t.Fatalf("failed to create bucket: %d %s", rec.Code, rec.Body)
+	}
+	if rec := do(t, http.MethodPut, "localhost:8000", "/bucket/object", "hello"); rec.Code != http.StatusOK {
+		t.Fatalf("failed to create object: %d %s", rec.Code, rec.Body)
+	}
+
+	tests := []struct {
+		name string
+		host string
+		path string
+	}{
+		{"path style with port", "localhost:8000", "/bucket/object"},
+		{"path style without port", "localhost", "/bucket/object"},
+		{"virtual-hosted style with port", "bucket.localhost:8000", "/object"},
+		{"virtual-hosted style without port", "bucket.localhost", "/object"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := do(t, http.MethodGet, test.host, test.path, "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body)
+			} else if body, err := io.ReadAll(rec.Result().Body); err != nil {
+				t.Fatal(err)
+			} else if string(body) != "hello" {
+				t.Fatalf("expected body %q, got %q", "hello", body)
+			}
+		})
+	}
 }

--- a/tox/tox_test.go
+++ b/tox/tox_test.go
@@ -94,7 +94,7 @@ func TestS3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}
-	server := &http.Server{Handler: s3.New(backend, s3.WithHostBucketBases([]string{"localhost"}), s3.WithLogger(log.Named("s3")))}
+	server := &http.Server{Handler: s3.New(backend, s3.WithLogger(log.Named("s3")))}
 	errCh := make(chan error, 1)
 	go func() {
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
If a client doesn't support path style requests it will fail to connect on localhost unless localhost is configured as a host base. This fixes this by implicitly handling localhost even without configuring it.