### PR TITLE
Adopt shared go-publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish
 
+# Controls when the action will run.
 on:
+  # Triggers the workflow on new SemVer tags
   push:
     branches:
       - master
@@ -13,192 +15,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  test:
-    permissions:
-      contents: read
-      pull-requests: read
-    uses: ./.github/workflows/go-test.yml
-  docker:
-    name: Publish Docker
-    needs:
-      - test
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          go-version: "1.26"
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
-        name: generate tags
-        id: meta
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=sha,prefix=
-            type=semver,pattern={{version}}
-      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-  binaries:
-    name: Publish Binaries
-    needs:
-      - test
-    strategy:
-      matrix:
-        include:
-          - OS: ubuntu-latest
-            GOARCH: amd64
-            RELEASE_PLATFORM: linux
-          - OS: ubuntu-latest
-            GOARCH: arm64
-            RELEASE_PLATFORM: linux
-          - OS: macos-latest
-            GOARCH: amd64
-            RELEASE_PLATFORM: macos
-          - OS: macos-latest
-            GOARCH: arm64
-            RELEASE_PLATFORM: macos
-          - OS: windows-latest
-            GOARCH: amd64
-            RELEASE_PLATFORM: windows
-    runs-on: ${{ matrix.OS }}
-    env:
-      CGO_ENABLED: 1
-      RELEASE_NAME: s3d_${{ matrix.RELEASE_PLATFORM }}_${{ matrix.GOARCH }}
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          go-version: "1.26"
-      - name: Setup Linux arm64 cross-compiler
-        if: ${{ matrix.OS == 'ubuntu-latest' && matrix.GOARCH == 'arm64' }}
-        run: |
-          sudo apt update
-          sudo apt install -y gcc-aarch64-linux-gnu
-      - name: Setup macOS
-        if: ${{ matrix.OS == 'macos-latest' }}
-        env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_KEY_B64: ${{ secrets.APPLE_KEY_B64 }}
-          APPLE_CERT_B64: ${{ secrets.APPLE_CERT_B64 }}
-          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
-          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
-        run: |
-          # extract apple cert
-          APPLE_CERT_PATH=$RUNNER_TEMP/apple_cert.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          echo -n "$APPLE_CERT_B64" | base64 --decode --output $APPLE_CERT_PATH
-
-          # extract apple key
-          mkdir -p ~/private_keys
-          APPLE_API_KEY_PATH=~/private_keys/AuthKey_$APPLE_API_KEY.p8
-          echo -n "$APPLE_KEY_B64" | base64 --decode --output $APPLE_API_KEY_PATH
-
-          # create temp keychain
-          security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security default-keychain -s $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # import keychain
-          security import $APPLE_CERT_PATH -P $APPLE_CERT_PASSWORD -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security find-identity -v $KEYCHAIN_PATH -p codesigning
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $APPLE_KEYCHAIN_PASSWORD $KEYCHAIN_PATH
-
-          # resync system clock https://github.com/actions/runner/issues/2996#issuecomment-1833103110
-          sudo sntp -sS time.windows.com
-      - name: Setup Windows
-        if: ${{ matrix.OS == 'windows-latest' }}
-        run: |
-          dotnet tool install --global AzureSignTool
-      - name: Generate
-        run: |
-          go mod download
-          go generate ./...
-      - name: Build Linux
-        if: ${{ matrix.OS == 'ubuntu-latest' }}
-        env:
-          GOOS: linux
-          GOARCH: ${{ matrix.GOARCH }}
-          CC: ${{ matrix.GOARCH == 'arm64' && 'aarch64-linux-gnu-gcc' || '' }}
-        run: go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/s3d
-      - name: Build macOS
-        if: ${{ matrix.OS == 'macos-latest' }}
-        env:
-          GOOS: darwin
-          GOARCH: ${{ matrix.GOARCH }}
-        run: go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w' ./cmd/s3d
-      - name: Build Windows
-        if: ${{ matrix.OS == 'windows-latest' }}
-        shell: bash
-        env:
-          GOOS: windows
-          GOARCH: ${{ matrix.GOARCH }}
-        run: go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/s3d
-      - name: Sign macOS
-        if: ${{ matrix.OS == 'macos-latest' }}
-        env:
-          APPLE_CERT_ID: ${{ secrets.APPLE_CERT_ID }}
-        run: |
-          for file in bin/*; do
-            /usr/bin/codesign --deep -f -v --timestamp -o runtime,library -s $APPLE_CERT_ID $file
-          done
-      - name: Sign Windows
-        if: ${{ matrix.OS == 'windows-latest' }}
-        shell: bash
-        run: |
-          for file in bin/*; do
-            azuresigntool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v $file
-          done
-      - name: Package macOS
-        if: ${{ matrix.OS == 'macos-latest' }}
-        env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: |
-          mkdir -p release
-          ZIP_OUTPUT=release/$RELEASE_NAME.zip
-          # copy meta files to bin
-          cp README.md LICENSE bin/
-          # zip binaries with ditto for notarytool
-          ditto -ck bin $ZIP_OUTPUT
-          # submit to notary service
-          xcrun notarytool submit -k ~/private_keys/AuthKey_$APPLE_API_KEY.p8 -d $APPLE_API_KEY -i $APPLE_API_ISSUER --wait --timeout 10m $ZIP_OUTPUT
-      - name: Package
-        if: ${{ matrix.OS != 'macos-latest' }}
-        shell: bash
-        run: |
-          mkdir -p release
-          ZIP_OUTPUT=release/$RELEASE_NAME.zip
-          cp README.md LICENSE bin/
-          7z a $ZIP_OUTPUT ./bin/*
-      - name: Upload Artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: release/*
-  combine-release-assets:
-    runs-on: ubuntu-latest
-    needs: binaries
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: s3d
+  publish:
+    uses: SiaFoundation/workflows/.github/workflows/go-publish.yml@dddded471aae1c7b6f0fbc388d603b8b16336f6f # master
+    secrets: inherit
+    with:
+      linux-build-args: -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'
+      windows-build-args: -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'
+      macos-build-args: -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w'
+      cgo-enabled: 1
+      project: s3d
+      project-desc: "s3d: An S3-compatible gateway for Sia"
+      version-tag: ${{ github.ref_name }}


### PR DESCRIPTION
Replaces the bespoke publish workflow with the shared `SiaFoundation/workflows` go-publish workflow, pinned to the same commit hostd, renterd and walletd use. Build args match the existing build lines.

@ChrisSchinnerl I noticed you added `binaries` job that produces the `s3d_linux_<arch>.zip` artifacts, any reason you didn't opt for the shared workflow? 

@ChrisSchinnerl  Can you check whether we have the `PAT_REPOSITORY_DISPATCH` set for this repo?
