### PR TITLE
Log errors caused by clients as DEBUG instead of ERROR to avoid spam

### DIFF
--- a/.changeset/dont_log_clients_disconnecting_as_errors.md
+++ b/.changeset/dont_log_clients_disconnecting_as_errors.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Don't log clients disconnecting as errors.

--- a/.changeset/only_log_errors_on_the_error_level_if_they_are_s3ds_fault_and_not_the_clients_to_avoid_spam.md
+++ b/.changeset/only_log_errors_on_the_error_level_if_they_are_s3ds_fault_and_not_the_clients_to_avoid_spam.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Only log errors on the error level if they are s3d's fault and not the client's to avoid spam.

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -343,14 +343,10 @@ func (s *s3) getObject(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 	}
 
 	// write body
-	if _, err := io.Copy(w, obj.Body); err != nil {
-		// log debug level if client disconnected to avoid spamming the logs
-		// when e.g. a video player aborta a range request on seek.
-		if r.Context().Err() != nil {
-			log.Debug("client disconnected while writing object body", zap.Error(err))
-		} else {
-			log.Error("failed to write object body", zap.Error(err))
-		}
+	if readErr, writeErr := streamBody(w, obj.Body); readErr != nil {
+		log.Error("failed to read object body", zap.Error(readErr))
+	} else if writeErr != nil {
+		log.Debug("failed to write object body", zap.Error(writeErr))
 	}
 	return nil
 }
@@ -1070,4 +1066,30 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 	}
 
 	return nil
+}
+
+// streamBody is the same as io.Copy but returns separate errors depending on
+// whether reading from src failed to writing to dst. If writing to dst fails,
+// it's usually the client disconnecting, so we don't want to log that as an
+// error. If reading from src fails, it's a backend error, so we do want
+// to log that.
+func streamBody(dst io.Writer, src io.Reader) (readErr, writeErr error) {
+	buf := make([]byte, 32*1024)
+	for {
+		nr, rerr := src.Read(buf)
+		if nr > 0 {
+			nw, werr := dst.Write(buf[:nr])
+			if werr != nil {
+				return nil, werr
+			}
+			if nw < nr {
+				return nil, io.ErrShortWrite
+			}
+		}
+		if rerr == io.EOF {
+			return nil, nil
+		} else if rerr != nil {
+			return rerr, nil
+		}
+	}
 }

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -343,10 +343,13 @@ func (s *s3) getObject(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 	}
 
 	// write body
-	if readErr, writeErr := streamBody(w, obj.Body); readErr != nil {
-		log.Error("failed to read object body", zap.Error(readErr))
-	} else if writeErr != nil {
-		log.Debug("failed to write object body", zap.Error(writeErr))
+	body := newErrTrackingReader(obj.Body)
+	if _, err := io.Copy(w, body); err != nil {
+		if readErr := body.Err(); readErr != nil {
+			log.Error("failed to read object body", zap.Error(readErr))
+		} else {
+			log.Debug("failed to write object body", zap.Error(err))
+		}
 	}
 	return nil
 }
@@ -1068,28 +1071,52 @@ func writeGetOrHeadObjectHeaders(obj *Object, w http.ResponseWriter, r *http.Req
 	return nil
 }
 
-// streamBody is the same as io.Copy but returns separate errors depending on
-// whether reading from src failed to writing to dst. If writing to dst fails,
-// it's usually the client disconnecting, so we don't want to log that as an
-// error. If reading from src fails, it's a backend error, so we do want
-// to log that.
-func streamBody(dst io.Writer, src io.Reader) (readErr, writeErr error) {
-	buf := make([]byte, 32*1024)
-	for {
-		nr, rerr := src.Read(buf)
-		if nr > 0 {
-			nw, werr := dst.Write(buf[:nr])
-			if werr != nil {
-				return nil, werr
-			}
-			if nw < nr {
-				return nil, io.ErrShortWrite
-			}
-		}
-		if rerr == io.EOF {
-			return nil, nil
-		} else if rerr != nil {
-			return rerr, nil
-		}
-	}
+// errTrackingReader is the interface returned by [newErrTrackingReader]: an
+// io.Reader that also reports, via Err, the last non-EOF error its underlying
+// reader returned.
+type errTrackingReader interface {
+	io.Reader
+	Err() error
 }
+
+// newErrTrackingReader wraps r so that, after copying it with io.Copy, the
+// caller can tell a read failure from a write failure: io.Copy returns the
+// error from whichever side failed, and a nil Err means the failure happened
+// while writing to the destination rather than reading from r.
+//
+// If r implements io.WriterTo the wrapper does too, preserving io.Copy's
+// WriterTo fast path. WriteTo bypasses Read, so read errors are not tracked on
+// that path, but the standard library's WriterTo readers only fail on the write
+// side, so such a failure is correctly attributed to the writer (Err stays
+// nil).
+func newErrTrackingReader(r io.Reader) errTrackingReader {
+	tr := &trackingReader{r: r}
+	if wt, ok := r.(io.WriterTo); ok {
+		return &trackingWriterTo{trackingReader: tr, wt: wt}
+	}
+	return tr
+}
+
+type trackingReader struct {
+	r   io.Reader
+	err error
+}
+
+func (t *trackingReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if err != nil && err != io.EOF {
+		t.err = err
+	}
+	return n, err
+}
+
+func (t *trackingReader) Err() error { return t.err }
+
+// trackingWriterTo is a trackingReader whose underlying reader also implements
+// io.WriterTo, so io.Copy keeps using the WriterTo fast path.
+type trackingWriterTo struct {
+	*trackingReader
+	wt io.WriterTo
+}
+
+func (t *trackingWriterTo) WriteTo(w io.Writer) (int64, error) { return t.wt.WriteTo(w) }

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -344,9 +344,13 @@ func (s *s3) getObject(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 
 	// write body
 	if _, err := io.Copy(w, obj.Body); err != nil {
-		// at this point we can't inform the client of the error anymore so
-		// we just log it
-		s.logger.Error("failed to write object body", zap.Error(err))
+		// log debug level if client disconnected to avoid spamming the logs
+		// when e.g. a video player aborta a range request on seek.
+		if r.Context().Err() != nil {
+			log.Debug("client disconnected while writing object body", zap.Error(err))
+		} else {
+			log.Error("failed to write object body", zap.Error(err))
+		}
 	}
 	return nil
 }

--- a/s3/objects_stream_test.go
+++ b/s3/objects_stream_test.go
@@ -1,0 +1,148 @@
+package s3
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+// readOnly wraps a reader so it does NOT satisfy io.WriterTo, forcing io.Copy
+// down the Read path (bytes.Reader would otherwise divert to WriteTo).
+type readOnly struct{ r io.Reader }
+
+func (r readOnly) Read(p []byte) (int, error) { return r.r.Read(p) }
+
+// failingReader returns its data and then fails with err, mimicking a backend
+// whose body read fails partway through. It does not implement io.WriterTo.
+type failingReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}
+
+// failingWriter accepts up to limit bytes and then fails with err, mimicking a
+// client connection that drops mid-response.
+type failingWriter struct {
+	limit   int
+	written int
+	err     error
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	if w.written >= w.limit {
+		return 0, w.err
+	}
+	n := len(p)
+	if w.written+n > w.limit {
+		n = w.limit - w.written
+		w.written += n
+		return n, w.err
+	}
+	w.written += n
+	return n, nil
+}
+
+// writerToSpy records whether the io.WriterTo fast path was taken.
+type writerToSpy struct {
+	r    *bytes.Reader
+	used bool
+}
+
+func (w *writerToSpy) Read(p []byte) (int, error) { return w.r.Read(p) }
+func (w *writerToSpy) WriteTo(dst io.Writer) (int64, error) {
+	w.used = true
+	return w.r.WriteTo(dst)
+}
+
+// copyBody mirrors how getObject classifies the failure: io.Copy through the
+// wrapper, then attribute by inspecting Err.
+func copyBody(dst io.Writer, src io.Reader) (copyErr, readErr error) {
+	body := newErrTrackingReader(src)
+	_, copyErr = io.Copy(dst, body)
+	return copyErr, body.Err()
+}
+
+func TestErrTrackingReader(t *testing.T) {
+	backendErr := errors.New("backend exploded")
+	clientErr := errors.New("connection reset by peer")
+	// larger than io.Copy's buffer so the Read path iterates repeatedly
+	payload := bytes.Repeat([]byte("abcd"), 32*1024)
+
+	t.Run("successful copy", func(t *testing.T) {
+		var got bytes.Buffer
+		copyErr, readErr := copyBody(&got, readOnly{bytes.NewReader(payload)})
+		if copyErr != nil || readErr != nil {
+			t.Fatalf("copyErr=%v readErr=%v, want both nil", copyErr, readErr)
+		}
+		if !bytes.Equal(got.Bytes(), payload) {
+			t.Fatalf("copied %d bytes, want %d", got.Len(), len(payload))
+		}
+	})
+
+	t.Run("read error is recorded by the wrapper", func(t *testing.T) {
+		copyErr, readErr := copyBody(&bytes.Buffer{}, &failingReader{data: []byte("hello"), err: backendErr})
+		if !errors.Is(readErr, backendErr) {
+			t.Fatalf("readErr=%v, want %v", readErr, backendErr)
+		}
+		if !errors.Is(copyErr, backendErr) {
+			t.Fatalf("copyErr=%v, want io.Copy to surface the read error", copyErr)
+		}
+	})
+
+	t.Run("write error leaves the wrapper's Err nil", func(t *testing.T) {
+		// readOnly forces the Read path; the writer fails partway through
+		copyErr, readErr := copyBody(&failingWriter{limit: 10 * 1024, err: clientErr}, readOnly{bytes.NewReader(payload)})
+		if copyErr == nil {
+			t.Fatal("expected io.Copy to fail on write")
+		}
+		if readErr != nil {
+			t.Fatalf("readErr=%v, want nil (write side failed, not read)", readErr)
+		}
+	})
+
+	t.Run("WriterTo fast path is preserved and leaves Err nil", func(t *testing.T) {
+		spy := &writerToSpy{r: bytes.NewReader(payload)}
+		var got bytes.Buffer
+		copyErr, readErr := copyBody(&got, spy)
+		if !spy.used {
+			t.Fatal("expected io.Copy to use the WriterTo fast path")
+		}
+		if copyErr != nil || readErr != nil {
+			t.Fatalf("copyErr=%v readErr=%v, want both nil", copyErr, readErr)
+		}
+		if !bytes.Equal(got.Bytes(), payload) {
+			t.Fatalf("copied %d bytes, want %d", got.Len(), len(payload))
+		}
+	})
+
+	t.Run("WriterTo write failure attributed to writer", func(t *testing.T) {
+		spy := &writerToSpy{r: bytes.NewReader(payload)}
+		copyErr, readErr := copyBody(&failingWriter{limit: 10 * 1024, err: clientErr}, spy)
+		if !spy.used {
+			t.Fatal("expected io.Copy to use the WriterTo fast path")
+		}
+		if readErr != nil {
+			t.Fatalf("readErr=%v, want nil", readErr)
+		}
+		if copyErr == nil {
+			t.Fatal("expected a copy error from the failing writer")
+		}
+	})
+
+	t.Run("EOF is not recorded as an error", func(t *testing.T) {
+		copyErr, readErr := copyBody(&bytes.Buffer{}, &failingReader{data: payload, err: io.EOF})
+		if copyErr != nil || readErr != nil {
+			t.Fatalf("copyErr=%v readErr=%v, want both nil", copyErr, readErr)
+		}
+	})
+}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -525,7 +526,14 @@ func (s *s3) routeBase(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 		return
 	}
 	if err != nil {
-		log.Error("failed to handle request", zap.Error(err))
+		// only consider 5xx errors as "real" errors when logging. Other errors
+		// like bad requests or not found errors are no our fault
+		var s3Err s3errs.Error
+		if errors.As(err, &s3Err) && s3Err.HTTPStatus < http.StatusInternalServerError {
+			log.Debug("failed to handle request", zap.Error(err))
+		} else {
+			log.Error("failed to handle request", zap.Error(err))
+		}
 		writeErrorResponse(w, err)
 	}
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -527,7 +527,7 @@ func (s *s3) routeBase(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 	}
 	if err != nil {
 		// only consider 5xx errors as "real" errors when logging. Other errors
-		// like bad requests or not found errors are no our fault
+		// like bad requests or not found errors are not our fault
 		var s3Err s3errs.Error
 		if errors.As(err, &s3Err) && s3Err.HTTPStatus < http.StatusInternalServerError {
 			log.Debug("failed to handle request", zap.Error(err))


### PR DESCRIPTION
While testing video streaming via external storage on Nextcloud I noticed some unnecessary spam in the logs.

One source of spam is all errors in handlers being logged on the error level even if they are not 5xx codes. e.g. bad requests or in Nextcloud's case 404s resulting from Nextcloud attempting to figure out if an object is a folder or file.

The other source is the client dropping range requests. Since there is no easy way to check for a broken connection I settled on assuming that no error that happens when calling Write on the http response body is worth to be logged as an error. 