### PR TITLE
Add disk usage timeout

### DIFF
--- a/.changeset/fail_puts_with_slowdown_when_disk_space_wait_times_out.md
+++ b/.changeset/fail_puts_with_slowdown_when_disk_space_wait_times_out.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+# Fail puts with SlowDown when waiting for disk space times out
+
+Requests that wait for disk usage to drop below the limit now give up after
+two minutes and return a 503 SlowDown error instead of blocking forever.
+Previously a blocked put could pin its handler goroutine indefinitely, even
+after the client disconnected, and prevent graceful shutdown from completing.

--- a/s3/response.go
+++ b/s3/response.go
@@ -88,6 +88,13 @@ func writeErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 // capped in size and time so a rejected upload never consumes an arbitrarily
 // large body. It returns true if the body was fully consumed.
 func drainRequestBody(w http.ResponseWriter, r *http.Request) bool {
+	// skip the drain when the declared body already exceeds the cap so a
+	// rejected upload does not delay its response reading bytes that end up
+	// discarded anyway
+	if r.ContentLength > maxDrainBytes {
+		return false
+	}
+
 	rc := http.NewResponseController(w)
 	hasDeadline := rc.SetReadDeadline(time.Now().Add(maxDrainTime)) == nil
 	_, err := io.CopyN(io.Discard, r.Body, maxDrainBytes+1)

--- a/s3/response.go
+++ b/s3/response.go
@@ -3,10 +3,21 @@ package s3
 import (
 	"encoding/xml"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/SiaFoundation/s3d/s3/s3errs"
+)
+
+const (
+	// maxDrainBytes bounds how much of a rejected request body is drained
+	// before giving up on connection reuse.
+	maxDrainBytes = 2 * MinUploadPartSize
+
+	// maxDrainTime bounds how long draining a rejected request body may take.
+	maxDrainTime = 5 * time.Second
 )
 
 // ErrorResponse is the standard XML error response returned by S3.
@@ -21,8 +32,9 @@ type ErrorResponse struct {
 
 // writeErrorResponse writes an error response to the ResponseWriter. The
 // provided err must not be nil. If err is not an [Error], [ErrInternalError]
-// is used.
-func writeErrorResponse(w http.ResponseWriter, err error) {
+// is used. Any unread remainder of the request body is drained up to a cap
+// first so the response is not lost to a connection reset.
+func writeErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	if err == nil {
 		panic("WriteErrorResponse called with nil error")
 	}
@@ -42,6 +54,8 @@ func writeErrorResponse(w http.ResponseWriter, err error) {
 		return
 	}
 
+	drained := drainRequestBody(w, r)
+
 	// a delete-marker error must still carry x-amz-delete-marker (and, for 405,
 	// Last-Modified/Allow) so clients can tell it apart from a missing object.
 	var keep []string
@@ -53,12 +67,34 @@ func writeErrorResponse(w http.ResponseWriter, err error) {
 	// (e.g. conditional GET sets ETag and metadata before checking If-Match)
 	clearHeadersExceptCORS(w.Header(), keep...)
 
+	// a connection with an unconsumed body cannot be reused
+	if !drained {
+		w.Header().Set("Connection", "close")
+	}
+
 	writeXMLResponse(w, s3Err.HTTPStatus, ErrorResponse{
 		Code:      s3Err.Code,
 		Message:   s3Err.Description,
 		RequestID: "", // unused right now (AWS uses it for diagnostic purposes)
 		HostID:    "", // unused right now (AWS uses it to identify their server)
 	})
+}
+
+// drainRequestBody consumes the unread remainder of a rejected request's body
+// so the error response is delivered over a healthy connection. Without the
+// drain net/http only discards small remainders itself and otherwise closes
+// the connection, and the resulting TCP reset races with the response so
+// clients may see a transport error instead of the S3 error. The drain is
+// capped in size and time so a rejected upload never consumes an arbitrarily
+// large body. It returns true if the body was fully consumed.
+func drainRequestBody(w http.ResponseWriter, r *http.Request) bool {
+	rc := http.NewResponseController(w)
+	hasDeadline := rc.SetReadDeadline(time.Now().Add(maxDrainTime)) == nil
+	_, err := io.CopyN(io.Discard, r.Body, maxDrainBytes+1)
+	if hasDeadline {
+		_ = rc.SetReadDeadline(time.Time{})
+	}
+	return errors.Is(err, io.EOF)
 }
 
 // clearHeadersExceptCORS removes every header from h except CORS headers set

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -522,13 +522,10 @@ func (s *s3) hostBucketBaseMiddleware(handler auth.AuthenticatedHandler) auth.Au
 //
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html
 func (s *s3) routeBase(w http.ResponseWriter, r *http.Request, accessKeyID *string) {
-	// close and drain the request body to allow connection reuse
-	defer func() {
-		if r.Body != nil {
-			_, _ = io.Copy(io.Discard, r.Body)
-			_ = r.Body.Close()
-		}
-	}()
+	// NOTE: the request body is intentionally not drained here. net/http
+	// discards small unread remainders itself to keep the connection alive
+	// and closes the connection for large ones, so a rejected upload never
+	// consumes the full body.
 
 	var (
 		path   = strings.TrimPrefix(r.URL.Path, "/")

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -457,7 +457,7 @@ func (s s3) authMiddleware(handler auth.AuthenticatedHandler) http.Handler {
 			akid, err := auth.HandleAuth(req, s.backend, region, time.Now())
 			if err != nil {
 				s.logger.Debug("authentication failed", zap.Error(err))
-				writeErrorResponse(w, err)
+				writeErrorResponse(w, req, err)
 				return
 			}
 			accessKeyID = &akid
@@ -522,10 +522,8 @@ func (s *s3) hostBucketBaseMiddleware(handler auth.AuthenticatedHandler) auth.Au
 //
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html
 func (s *s3) routeBase(w http.ResponseWriter, r *http.Request, accessKeyID *string) {
-	// NOTE: the request body is intentionally not drained here. net/http
-	// discards small unread remainders itself to keep the connection alive
-	// and closes the connection for large ones, so a rejected upload never
-	// consumes the full body.
+	// NOTE: the request body is not drained here. Handlers consume it on
+	// success and writeErrorResponse performs a bounded drain on failure.
 
 	var (
 		path   = strings.TrimPrefix(r.URL.Path, "/")
@@ -582,7 +580,7 @@ func (s *s3) routeBase(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 		} else {
 			log.Error("failed to handle request", zap.Error(err))
 		}
-		writeErrorResponse(w, err)
+		writeErrorResponse(w, r, err)
 	}
 }
 

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -250,5 +251,70 @@ func TestHostBucketStyles(t *testing.T) {
 				t.Fatalf("expected body %q, got %q", "hello", body)
 			}
 		})
+	}
+}
+
+// TestErrorResponseDrain verifies that a rejected request with an unread body
+// still receives its error response over a connection that stays reusable and
+// that a body over the drain cap closes the connection instead.
+func TestErrorResponseDrain(t *testing.T) {
+	backend, _ := testutil.NewBackend(t)
+	handler := s3.New(backend, s3.WithLogger(zaptest.NewLogger(t)))
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	// anonymous puts are rejected with AccessDenied before the body is read
+	var reused bool
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) { reused = info.Reused },
+	}
+	ctx := httptrace.WithClientTrace(t.Context(), trace)
+
+	doPut := func(size int64) *http.Response {
+		t.Helper()
+		body := bytes.Repeat([]byte("a"), int(size))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, server.URL+"/bucket/object", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			t.Fatal(err)
+		} else if err := resp.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	// a body of minimum part size is drained so the response arrives on a
+	// connection that stays alive
+	resp := doPut(s3.MinUploadPartSize)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatal("unexpected", resp.StatusCode)
+	} else if resp.Close {
+		t.Fatal("expected connection to stay alive")
+	}
+
+	// the second request reuses the drained connection
+	resp = doPut(s3.MinUploadPartSize)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatal("unexpected", resp.StatusCode)
+	} else if !reused {
+		t.Fatal("expected connection reuse")
+	}
+
+	// a body over the drain cap is not consumed and the connection is marked
+	// to close after the response
+	big := bytes.Repeat([]byte("a"), int(3*s3.MinUploadPartSize))
+	req := httptest.NewRequest(http.MethodPut, "/bucket/object", bytes.NewReader(big))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatal("unexpected", rec.Code)
+	} else if rec.Header().Get("Connection") != "close" {
+		t.Fatal("expected Connection close header")
 	}
 }

--- a/sia/export_test.go
+++ b/sia/export_test.go
@@ -8,6 +8,11 @@ import (
 // OrphanLoopInterval exports orphanLoopInterval for testing.
 const OrphanLoopInterval = orphanLoopInterval
 
+// SetDiskUsageTimeout overrides the disk usage timeout for testing.
+func (s *Sia) SetDiskUsageTimeout(d time.Duration) { //nolint:revive
+	s.diskUsageTimeout = d
+}
+
 // ApplyLifecycleRules exports applyLifecycleRules for testing.
 func (s *Sia) ApplyLifecycleRules(ctx context.Context, now time.Time) { //nolint:revive
 	s.applyLifecycleRules(ctx, now)

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/SiaFoundation/s3d/s3"
 	"github.com/SiaFoundation/s3d/s3/s3errs"
@@ -21,13 +22,17 @@ import (
 )
 
 // addDiskUsage reserves size bytes against the disk usage limit, blocking
-// until enough space is available. If allowExcess returns true the
-// reservation bypasses the limit; it is re-evaluated each time
+// until enough space is available. If no space frees up within the disk
+// usage timeout it fails with ErrSlowDown so clients can back off and
+// retry instead of pinning a handler indefinitely. If allowExcess returns
+// true the reservation bypasses the limit; it is re-evaluated each time
 // releaseDiskUsage is called.
 func (s *Sia) addDiskUsage(ctx context.Context, size int64, allowExcess func() (bool, error)) error {
 	if size <= 0 || s.diskUsageLimit == 0 {
 		return nil
 	}
+	timeout := time.NewTimer(s.diskUsageTimeout)
+	defer timeout.Stop()
 	for {
 		s.diskUsageMu.Lock()
 		wake := s.diskUsageWake
@@ -53,6 +58,8 @@ func (s *Sia) addDiskUsage(ctx context.Context, size int64, allowExcess func() (
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-timeout.C:
+			return s3errs.ErrSlowDown
 		case <-wake:
 		}
 	}

--- a/sia/objects_test.go
+++ b/sia/objects_test.go
@@ -1284,6 +1284,65 @@ func TestDiskUsageLimit(t *testing.T) {
 	}
 }
 
+func TestDiskUsageLimitTimeout(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	dir := t.TempDir()
+	store, err := sqlite.OpenDatabase(filepath.Join(dir, "s3d.sqlite"), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	if err := store.CreateUser(testutil.Owner); err != nil {
+		t.Fatal(err)
+	} else if err := store.CreateAccessKey(testutil.Owner, testutil.AccessKeyID, testutil.SecretAccessKey); err != nil {
+		t.Fatal(err)
+	}
+
+	const limit = 500
+	memSDK := testutil.NewMemorySDK()
+	memSDK.SetSlabSize(100)
+	backend, err := sia.New(t.Context(), memSDK, store, dir,
+		sia.WithUploadDisabled(),
+		sia.WithDiskUsageLimit(limit),
+		sia.WithLogger(log))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { backend.Close() })
+	backend.SetDiskUsageTimeout(100 * time.Millisecond)
+	s3Tester := testutil.NewTester(t, testutil.WithBackend(backend))
+
+	const bucket = "bucket"
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	// push usage over the limit
+	if _, err := s3Tester.PutObject(t.Context(), bucket, "a", bytes.NewReader(frand.Bytes(600)), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// a put blocked at the limit fails with SlowDown once the wait times out
+	data := frand.Bytes(10)
+	_, err = backend.PutObject(t.Context(), testutil.AccessKeyID, bucket, "b", bytes.NewReader(data), s3.PutObjectOptions{ContentLength: int64(len(data))})
+	if !errors.Is(err, s3errs.ErrSlowDown) {
+		t.Fatal("unexpected", err)
+	}
+
+	// a blocked put unblocks when its context is cancelled before the timeout
+	backend.SetDiskUsageTimeout(time.Minute)
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	_, err = backend.PutObject(ctx, testutil.AccessKeyID, bucket, "c", bytes.NewReader(data), s3.PutObjectOptions{ContentLength: int64(len(data))})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("unexpected", err)
+	}
+}
+
 func TestDiskUsageLimitOngoingMultipartUpload(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -37,6 +37,10 @@ const (
 	// a single "day" when evaluating lifecycle Days windows.
 	defaultLifecycleDayDuration = 24 * time.Hour
 
+	// defaultDiskUsageTimeout is the maximum time a request waits for disk
+	// space to become available before failing with ErrSlowDown.
+	defaultDiskUsageTimeout = 2 * time.Minute
+
 	// UploadsDirectory is the directory name used for storing pending uploads.
 	UploadsDirectory = "uploads"
 )
@@ -115,8 +119,9 @@ type Sia struct {
 
 	directory string
 
-	slabSize       int64
-	diskUsageLimit uint64
+	slabSize         int64
+	diskUsageLimit   uint64
+	diskUsageTimeout time.Duration
 
 	diskUsageMu   sync.Mutex
 	diskUsageWake chan struct{}
@@ -232,6 +237,7 @@ func New(ctx context.Context, sdk SDK, store Store, directory string, opts ...Op
 		uploadWastePct:        DefaultUploadWastePct,
 		lifecycleLoopInterval: defaultLifecycleLoopInterval,
 		lifecycleDayDuration:  defaultLifecycleDayDuration,
+		diskUsageTimeout:      defaultDiskUsageTimeout,
 		lockedUploads:         make(map[string]*lockedUpload),
 
 		logger: zap.NewNop(),


### PR DESCRIPTION
So while I was verifying #232 I found out that PUTs can hang indefinitely when you have an instance whose pending uploads can never complete. That can happen if you change the disk usage limit and your database is still in a previous state, I ran into it with a 50gb file put a 10gb default cap. 

Roughly what happens is that `addDiskUsage` parks a request until the usage drops below the limit, it does that before the request body is read and thereby the FIN you'd get from trying to shut down the server goes unnoticed. Every time the client retries it essentially adds another permanently blocked handler.

This bounds the wait to a (relatively) generous two minutes, and returns a 503 SlowDown, preventing the clients from retrying and allowing the server to shut down gracefully.