### PR TITLE
Add bucket policies for anonymous access

### DIFF
--- a/.changeset/add_support_for_public_buckets_via_bucket_policies.md
+++ b/.changeset/add_support_for_public_buckets_via_bucket_policies.md
@@ -1,0 +1,14 @@
+---
+default: minor
+---
+
+# Added support for public buckets via bucket policies
+
+`PutBucketPolicy`, `GetBucketPolicy`, `DeleteBucketPolicy` and
+`GetBucketPolicyStatus` are now implemented for policies that grant read access
+to everyone. A policy may allow `s3:GetObject`, `s3:GetObjectVersion`,
+`s3:ListBucket` and `s3:ListBucketVersions` to the `*` principal, which lets
+any caller respectively read an object, read a specific version of one, list
+the bucket, and list its versions. The grant covers unsigned requests as well
+as signed requests from other users. Each action is granted independently, and
+every other policy is rejected rather than partially applied.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,55 @@ AWS Signature V4 exclusively. SigV4A is not implemented. Supported
 
 Bucket lifecycle configuration supports prefix-based `AbortIncompleteMultipartUpload` rules and current-object `Expiration` rules.
 
+Bucket policies are supported only to grant read access to everyone.
+`PutBucketPolicy` accepts `Allow` statements whose principal is `*` and whose
+actions are drawn from this set:
+
+| Action | Resource | Grants |
+|--------|----------|--------|
+| `s3:GetObject` | `arn:aws:s3:::<bucket>/*` | `GetObject`, `HeadObject` |
+| `s3:GetObjectVersion` | `arn:aws:s3:::<bucket>/*` | `GetObject`, `HeadObject` for a specific `versionId` |
+| `s3:ListBucket` | `arn:aws:s3:::<bucket>` | `ListObjects` v1 and v2 |
+| `s3:ListBucketVersions` | `arn:aws:s3:::<bucket>` | `ListObjectVersions` |
+
+Each action is granted on its own, so a policy that allows listing does not also
+allow reading. An action paired with the wrong resource grants nothing, as in
+S3. A policy granting everything looks like this:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:GetObject", "s3:GetObjectVersion"],
+      "Resource": "arn:aws:s3:::<bucket>/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:ListBucket", "s3:ListBucketVersions"],
+      "Resource": "arn:aws:s3:::<bucket>"
+    }
+  ]
+}
+```
+
+A `*` principal covers every caller, so the grant applies to signed requests
+from other users as well as to unsigned ones. Nothing beyond those four actions
+follows from it: writes, deletes, `HeadBucket` and the bucket's own
+configuration all still require the owner's credentials, only the owner can
+read, change or remove the policy, and the bucket does not appear in anyone
+else's `ListBuckets`. A listing reports the bucket's owner, which is not
+necessarily the caller.
+
+Any policy s3d cannot honor exactly is rejected rather than partially applied,
+so an accepted policy never grants more access than it describes: `Deny`
+statements, `Condition` blocks, named principals, other actions, resources
+scoped to a key prefix, and unrecognised members of any kind are all refused.
+ACLs remain unimplemented, as does `PublicAccessBlock`.
+
 Conditional requests are supported. `GetObject` and `HeadObject` honor
 `If-Match`, `If-None-Match`, `If-Modified-Since` and `If-Unmodified-Since`, and
 the copy source of `CopyObject` and `UploadPartCopy` honors the matching
@@ -224,53 +273,59 @@ delete with nothing to delete is a no-op, as an unconditional one is.
 
 ### Operations
 
-| Operation | Status |
-|-----------|--------|
-| **Buckets** | |
-| CreateBucket | ✓ |
-| DeleteBucket | ✓ |
-| HeadBucket | ✓ |
-| ListBuckets | ✓ |
-| GetBucketLocation | ✓ |
-| GetBucketVersioning | ✗ |
-| PutBucketVersioning | ✗ |
-| GetBucketAcl | ✗ |
-| PutBucketAcl | ✗ |
-| GetBucketPolicy | ✗ |
-| PutBucketPolicy | ✗ |
-| GetBucketLifecycle | ✓ |
-| PutBucketLifecycle | ✓ |
-| DeleteBucketLifecycle | ✓ |
-| GetBucketCors | ✗ |
-| PutBucketCors | ✗ |
-| GetBucketTagging | ✗ |
-| PutBucketTagging | ✗ |
-| GetBucketEncryption | ✗ |
-| PutBucketEncryption | ✗ |
-| **Objects** | |
-| PutObject | ✓ |
-| GetObject | ✓ |
-| HeadObject | ✓ |
-| DeleteObject | ✓ |
-| DeleteObjects | ✓ |
-| CopyObject | ✓ |
-| ListObjects (v1) | ✓ |
-| ListObjects (v2) | ✓ |
-| GetObjectAcl | ✗ |
-| PutObjectAcl | ✗ |
-| GetObjectTagging | ✗ |
-| PutObjectTagging | ✗ |
-| GetObjectLock | ✗ |
-| PutObjectLock | ✗ |
-| SelectObjectContent | ✗ |
-| **Multipart** | |
-| CreateMultipartUpload | ✓ |
-| UploadPart | ✓ |
-| UploadPartCopy | ✓ |
-| CompleteMultipartUpload | ✓ |
-| AbortMultipartUpload | ✓ |
-| ListParts | ✓ |
-| ListMultipartUploads | ✓ |
+✓ fully supported, ◐ supported with the limitations listed, ✗ not implemented.
+
+| Operation | Status | Limitations |
+|-----------|--------|-------------|
+| **Buckets** | | |
+| CreateBucket | ✓ | |
+| DeleteBucket | ✓ | |
+| HeadBucket | ◐ | Requires credentials; `s3:ListBucket` does not expose it anonymously |
+| ListBuckets | ✓ | |
+| GetBucketLocation | ✓ | |
+| GetBucketVersioning | ✓ | |
+| PutBucketVersioning | ◐ | `MfaDelete` is rejected; `Enabled` and `Suspended` are supported |
+| GetBucketAcl | ✗ | |
+| PutBucketAcl | ✗ | |
+| GetBucketPolicy | ✓ | |
+| PutBucketPolicy | ◐ | `Allow` only, principal `*` only, and only the four read actions listed above |
+| DeleteBucketPolicy | ✓ | |
+| GetBucketPolicyStatus | ✓ | |
+| GetBucketLifecycle | ✓ | |
+| PutBucketLifecycle | ◐ | Prefix-based `AbortIncompleteMultipartUpload` and current-object `Expiration` rules only |
+| DeleteBucketLifecycle | ✓ | |
+| GetBucketCors | ✗ | |
+| PutBucketCors | ✗ | |
+| GetBucketTagging | ✗ | |
+| PutBucketTagging | ✗ | |
+| GetBucketEncryption | ✗ | |
+| PutBucketEncryption | ✗ | |
+| PublicAccessBlock | ✗ | |
+| **Objects** | | |
+| PutObject | ✓ | |
+| GetObject | ✓ | |
+| HeadObject | ✓ | |
+| DeleteObject | ✓ | |
+| DeleteObjects | ✓ | |
+| CopyObject | ✓ | |
+| ListObjects (v1) | ✓ | |
+| ListObjects (v2) | ✓ | |
+| ListObjectVersions | ✓ | |
+| GetObjectAcl | ✗ | |
+| PutObjectAcl | ✗ | |
+| GetObjectTagging | ✗ | |
+| PutObjectTagging | ✗ | |
+| GetObjectLock | ✗ | |
+| PutObjectLock | ✗ | |
+| SelectObjectContent | ✗ | |
+| **Multipart** | | |
+| CreateMultipartUpload | ✓ | |
+| UploadPart | ✓ | |
+| UploadPartCopy | ✓ | |
+| CompleteMultipartUpload | ✓ | |
+| AbortMultipartUpload | ✓ | |
+| ListParts | ✓ | |
+| ListMultipartUploads | ✓ | |
 
 ## Configuration
 

--- a/build/gen.go
+++ b/build/gen.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"encoding/json"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"log"

--- a/cmd/s3d/status.go
+++ b/cmd/s3d/status.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/v2"
 	"flag"
 	"fmt"
 	"net/http"
@@ -64,7 +64,7 @@ func fetchUploadStats(ctx context.Context, addr, password string) (s3.UploadStat
 	}
 
 	var stats s3.UploadStats
-	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+	if err := json.UnmarshalRead(resp.Body, &stats); err != nil {
 		return s3.UploadStats{}, fmt.Errorf("failed to decode response: %w", err)
 	}
 	return stats, nil

--- a/internal/prometheus/encoder.go
+++ b/internal/prometheus/encoder.go
@@ -1,7 +1,7 @@
 package prometheus
 
 import (
-	"encoding/json"
+	"encoding/json/v2"
 	"fmt"
 	"io"
 	"strings"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -65,25 +65,72 @@ type DeleteConditions struct {
 // ChangeAccessKey creates a copy of the tester that uses the provided keypair
 // to access the S3 API.
 func (t *S3Tester) ChangeAccessKey(tb testing.TB, accessKeyID, secretKey string) *S3Tester {
-	client := service.NewFromConfig(t.cfg, func(o *service.Options) {
+	return t.withCredentials(aws.NewCredentialsCache(&credentials.StaticCredentialsProvider{
+		Value: aws.Credentials{
+			AccessKeyID:     accessKeyID,
+			SecretAccessKey: secretKey,
+		},
+	}))
+}
+
+// withCredentials returns a copy of the tester whose client signs with creds.
+func (t *S3Tester) withCredentials(creds aws.CredentialsProvider) *S3Tester {
+	c := *t
+	c.client = service.NewFromConfig(t.cfg, func(o *service.Options) {
 		*o = t.client.Options()
-		o.Credentials = aws.NewCredentialsCache(&credentials.StaticCredentialsProvider{
-			Value: aws.Credentials{
-				AccessKeyID:     accessKeyID,
-				SecretAccessKey: secretKey,
-			},
-		})
+		o.Credentials = creds
 	})
-	return &S3Tester{
-		cfg:     t.cfg,
-		backend: t.backend,
-		client:  client,
-	}
+	return &c
 }
 
 // Client returns the tester's S3 client.
 func (t *S3Tester) Client() *service.Client {
 	return t.client
+}
+
+// Anonymous returns a copy of the tester whose client sends unsigned requests,
+// so the server handles every call through it as anonymous.
+func (t *S3Tester) Anonymous() *S3Tester {
+	return t.withCredentials(aws.AnonymousCredentials{})
+}
+
+// PutBucketPolicy sets the policy of a bucket.
+func (t *S3Tester) PutBucketPolicy(ctx context.Context, bucket, policy string) error {
+	_, err := t.client.PutBucketPolicy(ctx, &service.PutBucketPolicyInput{
+		Bucket: aws.String(bucket),
+		Policy: aws.String(policy),
+	})
+	return err
+}
+
+// GetBucketPolicy returns the policy document of a bucket.
+func (t *S3Tester) GetBucketPolicy(ctx context.Context, bucket string) (string, error) {
+	resp, err := t.client.GetBucketPolicy(ctx, &service.GetBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(resp.Policy), nil
+}
+
+// DeleteBucketPolicy removes the policy of a bucket.
+func (t *S3Tester) DeleteBucketPolicy(ctx context.Context, bucket string) error {
+	_, err := t.client.DeleteBucketPolicy(ctx, &service.DeleteBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	})
+	return err
+}
+
+// GetBucketPolicyStatus reports whether a bucket's policy makes it public.
+func (t *S3Tester) GetBucketPolicyStatus(ctx context.Context, bucket string) (bool, error) {
+	resp, err := t.client.GetBucketPolicyStatus(ctx, &service.GetBucketPolicyStatusInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return false, err
+	}
+	return aws.ToBool(resp.PolicyStatus.IsPublic), nil
 }
 
 // AddObject adds an object to the S3 backend.
@@ -106,10 +153,19 @@ func (t *S3Tester) BucketLocation(ctx context.Context, bucket string) (string, e
 	return string(resp.LocationConstraint), nil
 }
 
+// copySource builds the x-amz-copy-source value, optionally pinned to a version.
+func copySource(bucket, object string, versionID *string) *string {
+	source := fmt.Sprintf("%s/%s", bucket, url.QueryEscape(object))
+	if versionID != nil {
+		source += "?versionId=" + url.QueryEscape(*versionID)
+	}
+	return aws.String(source)
+}
+
 // CopyObject is a convenience wrapper around the AWS SDK's CopyObject API.
 func (t *S3Tester) CopyObject(ctx context.Context, srcBucket, srcObject, dstBucket, dstObject string, dir types.MetadataDirective, meta map[string]string) ([]byte, error) {
 	resp, err := t.client.CopyObject(ctx, &service.CopyObjectInput{
-		CopySource:        aws.String(fmt.Sprintf("%s/%s", srcBucket, url.QueryEscape(srcObject))),
+		CopySource:        copySource(srcBucket, srcObject, nil),
 		Bucket:            aws.String(dstBucket),
 		Key:               aws.String(dstObject),
 		MetadataDirective: dir,
@@ -126,7 +182,7 @@ func (t *S3Tester) CopyObject(ctx context.Context, srcBucket, srcObject, dstBuck
 // the object the copy replaces.
 func (t *S3Tester) ConditionalCopyObject(ctx context.Context, srcBucket, srcObject, dstBucket, dstObject string, src, dst Preconditions) error {
 	_, err := t.client.CopyObject(ctx, &service.CopyObjectInput{
-		CopySource:                  aws.String(fmt.Sprintf("%s/%s", srcBucket, url.QueryEscape(srcObject))),
+		CopySource:                  copySource(srcBucket, srcObject, nil),
 		Bucket:                      aws.String(dstBucket),
 		Key:                         aws.String(dstObject),
 		CopySourceIfMatch:           src.IfMatch,
@@ -453,8 +509,10 @@ func (t *S3Tester) UploadPart(ctx context.Context, bucket, object, uploadID stri
 
 // UploadPartCopyOptions are the options for an UploadPartCopy request.
 type UploadPartCopyOptions struct {
-	PartNumber          int32
-	Range               *s3.ObjectRange
+	PartNumber int32
+	Range      *s3.ObjectRange
+	// SourceVersionID selects a specific version of the copy source.
+	SourceVersionID     *string
 	SourcePreconditions Preconditions
 }
 
@@ -466,7 +524,7 @@ func (t *S3Tester) UploadPartCopy(ctx context.Context, srcBucket, srcObject, dst
 		copySourceRange = aws.String(fmt.Sprintf("bytes=%d-%d", rnge.Start, rnge.Start+rnge.Length-1))
 	}
 	input := &service.UploadPartCopyInput{
-		CopySource:                  aws.String(fmt.Sprintf("%s/%s", srcBucket, url.QueryEscape(srcObject))),
+		CopySource:                  copySource(srcBucket, srcObject, opts.SourceVersionID),
 		Bucket:                      aws.String(dstBucket),
 		Key:                         aws.String(dstObject),
 		UploadId:                    aws.String(uploadID),
@@ -612,12 +670,8 @@ func (t *S3Tester) DeleteObjectVersion(ctx context.Context, bucket, object strin
 // CopyObjectVersion copies a source object onto the destination key, optionally
 // addressing a specific source version when srcVersionID is non-nil.
 func (t *S3Tester) CopyObjectVersion(ctx context.Context, srcBucket, srcObject string, srcVersionID *string, dstBucket, dstObject string) (*service.CopyObjectOutput, error) {
-	source := fmt.Sprintf("%s/%s", srcBucket, url.QueryEscape(srcObject))
-	if srcVersionID != nil {
-		source += "?versionId=" + url.QueryEscape(*srcVersionID)
-	}
 	return t.client.CopyObject(ctx, &service.CopyObjectInput{
-		CopySource: aws.String(source),
+		CopySource: copySource(srcBucket, srcObject, srcVersionID),
 		Bucket:     aws.String(dstBucket),
 		Key:        aws.String(dstObject),
 	})

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -22,8 +22,6 @@ var unsupportedBucketSubresources = map[string]struct{}{
 	"notification":        {},
 	"object-lock":         {},
 	"ownershipControls":   {},
-	"policy":              {},
-	"policyStatus":        {},
 	"publicAccessBlock":   {},
 	"replication":         {},
 	"requestPayment":      {},
@@ -34,11 +32,6 @@ var unsupportedBucketSubresources = map[string]struct{}{
 // routeBucket handles URLs that contain only a bucket path segment, not an
 // object path segment.
 func (s *s3) routeBucket(w http.ResponseWriter, r *http.Request, accessKeyID *string, bucket string) error {
-	validatedKey, err := assertAuth(accessKeyID)
-	if err != nil {
-		return err
-	}
-
 	q := r.URL.Query()
 	for param := range q {
 		if _, ok := unsupportedBucketSubresources[param]; ok {
@@ -46,20 +39,34 @@ func (s *s3) routeBucket(w http.ResponseWriter, r *http.Request, accessKeyID *st
 		}
 	}
 
-	if _, ok := q["lifecycle"]; ok {
-		return s.routeBucketLifecycle(w, r, validatedKey, bucket)
+	// the subresources read or configure the bucket itself; each asserts
+	// ownership for itself
+	switch {
+	case q.Has("lifecycle"):
+		return s.routeBucketLifecycle(w, r, accessKeyID, bucket)
+	case q.Has("policy"):
+		return s.routeBucketPolicy(w, r, accessKeyID, bucket)
+	case q.Has("policyStatus"):
+		return s.routeBucketPolicyStatus(w, r, accessKeyID, bucket)
+	case q.Has("location"):
+		return s.bucketLocation(w, r, accessKeyID, bucket)
 	}
 
-	switch r.Method {
-	case http.MethodGet:
-		// nolint:gocritic
-		if _, ok := q["location"]; ok {
-			return s.bucketLocation(w, r, validatedKey, bucket)
-		} else if q.Get("list-type") == "2" {
+	// routes with optional authentication. The backend rejects an anonymous
+	// listing unless the bucket's policy grants s3:ListBucket.
+	if r.Method == http.MethodGet {
+		if q.Get("list-type") == "2" {
 			return s.listObjectsV2(w, r, accessKeyID, bucket)
-		} else {
-			return s.listObjectsV1(w, r, accessKeyID, bucket)
 		}
+		return s.listObjectsV1(w, r, accessKeyID, bucket)
+	}
+
+	// routes with mandatory authentication
+	validatedKey, err := assertAuth(accessKeyID)
+	if err != nil {
+		return err
+	}
+	switch r.Method {
 	case http.MethodPut:
 		return s.createBucket(w, r, validatedKey, bucket)
 	case http.MethodDelete:
@@ -67,12 +74,10 @@ func (s *s3) routeBucket(w http.ResponseWriter, r *http.Request, accessKeyID *st
 	case http.MethodHead:
 		return s.headBucket(w, r, validatedKey, bucket)
 	case http.MethodPost:
-		// nolint:gocritic
-		if _, ok := q["delete"]; ok {
-			return s.deleteObjects(w, r, *accessKeyID, bucket)
-		} else {
+		if !q.Has("delete") {
 			return s3errs.ErrNotImplemented // createObjectBrowserUpload is not implemented
 		}
+		return s.deleteObjects(w, r, validatedKey, bucket)
 	default:
 		return s3errs.ErrMethodNotAllowed
 	}
@@ -81,10 +86,16 @@ func (s *s3) routeBucket(w http.ResponseWriter, r *http.Request, accessKeyID *st
 // bucketLocation handles GET Bucket location requests.
 //
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
-func (s *s3) bucketLocation(w http.ResponseWriter, r *http.Request, accessKeyID, bucket string) error {
+func (s *s3) bucketLocation(w http.ResponseWriter, r *http.Request, accessKeyID *string, bucket string) error {
+	validatedKey, err := assertAuth(accessKeyID)
+	if err != nil {
+		return err
+	} else if r.Method != http.MethodGet {
+		return s3errs.ErrMethodNotAllowed
+	}
 	s.logger.Debug("getting bucket location", zap.String("bucket", bucket))
 
-	if err := s.backend.HeadBucket(r.Context(), accessKeyID, bucket); err != nil {
+	if err := s.backend.HeadBucket(r.Context(), validatedKey, bucket); err != nil {
 		return err
 	}
 
@@ -111,11 +122,8 @@ func (s *s3) createBucket(w http.ResponseWriter, r *http.Request, accessKeyID, b
 		return err
 	}
 
-	q := r.URL.Query()
-	if _, hasACL := q["acl"]; hasACL {
+	if r.URL.Query().Has("acl") {
 		return s3errs.ErrNotImplemented // ACLs are not implemented
-	} else if _, hasPolicy := q["policy"]; hasPolicy {
-		return s3errs.ErrNotImplemented // Bucket policies are not implemented
 	}
 
 	if err := s.backend.CreateBucket(r.Context(), accessKeyID, bucket); err != nil {

--- a/s3/lifecycle.go
+++ b/s3/lifecycle.go
@@ -278,14 +278,18 @@ func (f *LifecycleFilter) validate() error {
 }
 
 // routeBucketLifecycle dispatches the ?lifecycle bucket subresource.
-func (s *s3) routeBucketLifecycle(w http.ResponseWriter, r *http.Request, accessKeyID, bucket string) error {
+func (s *s3) routeBucketLifecycle(w http.ResponseWriter, r *http.Request, accessKeyID *string, bucket string) error {
+	validatedKey, err := assertAuth(accessKeyID)
+	if err != nil {
+		return err
+	}
 	switch r.Method {
 	case http.MethodPut:
-		return s.putBucketLifecycle(w, r, accessKeyID, bucket)
+		return s.putBucketLifecycle(w, r, validatedKey, bucket)
 	case http.MethodGet:
-		return s.getBucketLifecycle(w, r, accessKeyID, bucket)
+		return s.getBucketLifecycle(w, r, validatedKey, bucket)
 	case http.MethodDelete:
-		return s.deleteBucketLifecycle(w, r, accessKeyID, bucket)
+		return s.deleteBucketLifecycle(w, r, validatedKey, bucket)
 	default:
 		return s3errs.ErrMethodNotAllowed
 	}

--- a/s3/messages.go
+++ b/s3/messages.go
@@ -509,6 +509,16 @@ type (
 
 // Types related to bucket versioning routes
 type (
+	// PolicyStatus is the response to GetBucketPolicyStatus.
+	//
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html
+	PolicyStatus struct {
+		XMLName xml.Name `xml:"PolicyStatus"`
+		Xmlns   string   `xml:"xmlns,attr,omitempty"`
+		// IsPublic is true when the policy grants anonymous callers access.
+		IsPublic bool `xml:"IsPublic"`
+	}
+
 	// VersioningConfiguration is the S3 bucket versioning configuration
 	// document used by PutBucketVersioning and GetBucketVersioning.
 	//

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -492,7 +492,7 @@ func (s *s3) listObjectsV1(w http.ResponseWriter, r *http.Request, accessKeyID *
 		return err
 	}
 
-	page := ListObjectsPage{MaxKeys: maxKeys}
+	page := ListObjectsPage{MaxKeys: maxKeys, FetchOwner: aws.Bool(true)}
 	if _, hasMarker := q["marker"]; hasMarker {
 		marker := q.Get("marker")
 		page.Marker = &marker

--- a/s3/policy.go
+++ b/s3/policy.go
@@ -1,0 +1,350 @@
+package s3
+
+import (
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/SiaFoundation/s3d/s3/s3errs"
+	"go.uber.org/zap"
+)
+
+const (
+	// the only policy language version accepted; "2008-10-17" defaults differ
+	policyVersion = "2012-10-17"
+
+	policyEffectAllow = "Allow"
+	policyEffectDeny  = "Deny"
+
+	// the only principal accepted, which makes a grant available to
+	// unauthenticated callers
+	policyWildcard = "*"
+
+	policyARNPrefix = "arn:aws:s3:::"
+
+	// matches the limit AWS enforces on bucket policies
+	maxPolicySize = 20 << 10
+)
+
+// PolicyActions is a set of S3 actions that a bucket policy grants to
+// everyone.
+type PolicyActions uint8
+
+// These values are stored verbatim in the buckets table, so a bit may never be
+// reordered or reused; a new action takes the next free bit.
+const (
+	// ActionGetObject grants GetObject and HeadObject for an object's current version.
+	ActionGetObject PolicyActions = 1
+	// ActionGetObjectVersion grants GetObject and HeadObject for a named version.
+	ActionGetObjectVersion PolicyActions = 2
+	// ActionListBucket grants ListObjects.
+	ActionListBucket PolicyActions = 4
+	// ActionListBucketVersions grants ListObjectVersions.
+	ActionListBucketVersions PolicyActions = 8
+)
+
+// S3 grants an object action on "<bucket>/*" and a bucket action on "<bucket>".
+const (
+	objectActions = ActionGetObject | ActionGetObjectVersion
+	bucketActions = ActionListBucket | ActionListBucketVersions
+)
+
+// ReadAction returns the action a read of the given version requires. The two
+// are granted separately, so every read path must ask for the one it performs.
+func ReadAction(version VersionRequest) PolicyActions {
+	if version.Specified {
+		return ActionGetObjectVersion
+	}
+	return ActionGetObject
+}
+
+// Allows reports whether every action in want is granted. An empty want is not
+// allowed: it is contained in every set, so treating it as satisfied would
+// authorize a caller that named no action against any policy, including none.
+func (a PolicyActions) Allows(want PolicyActions) bool {
+	return want != 0 && a&want == want
+}
+
+var supportedPolicyActions = map[string]PolicyActions{
+	"s3:GetObject":          ActionGetObject,
+	"s3:GetObjectVersion":   ActionGetObjectVersion,
+	"s3:ListBucket":         ActionListBucket,
+	"s3:ListBucketVersions": ActionListBucketVersions,
+}
+
+// BucketPolicy is a bucket policy accepted by [parseBucketPolicy].
+type BucketPolicy struct {
+	// Document is the policy JSON as the client supplied it. It is kept
+	// verbatim so GetBucketPolicy round-trips byte-for-byte, which clients like
+	// Terraform rely on to detect drift.
+	Document string
+
+	// Public is the set of actions the policy grants to everyone, which
+	// includes signed requests from other users as well as unsigned ones. It is
+	// derived once, when the policy is stored.
+	Public PolicyActions
+}
+
+// policyDocument is the JSON form of a bucket policy, whose keys are PascalCase.
+//
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html
+//
+// nolint:tagliatelle
+type policyDocument struct {
+	Version   string           `json:"Version"`
+	ID        string           `json:"Id"`
+	Statement policyStatements `json:"Statement"`
+}
+
+// policyStatements is the Statement element, which AWS allows as either a
+// single statement or an array of them.
+type policyStatements []policyStatement
+
+// UnmarshalJSONFrom implements json.UnmarshalerFrom. Decoding through the
+// caller's decoder keeps its options, so members unknown to a statement are
+// still rejected.
+func (p *policyStatements) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	if dec.PeekKind() == '{' {
+		var single policyStatement
+		if err := json.UnmarshalDecode(dec, &single); err != nil {
+			return err
+		}
+		*p = policyStatements{single}
+		return nil
+	}
+	return json.UnmarshalDecode(dec, (*[]policyStatement)(p))
+}
+
+// policyStatement is a single statement of a [policyDocument]. The elements s3d
+// cannot honor are still parsed so their presence can be rejected.
+//
+// nolint:tagliatelle
+type policyStatement struct {
+	Sid       string          `json:"Sid"`
+	Effect    string          `json:"Effect"`
+	Principal policyPrincipal `json:"Principal"`
+	Action    policyStrings   `json:"Action"`
+	Resource  policyStrings   `json:"Resource"`
+
+	NotPrincipal jsontext.Value `json:"NotPrincipal"`
+	NotAction    jsontext.Value `json:"NotAction"`
+	NotResource  jsontext.Value `json:"NotResource"`
+	Condition    jsontext.Value `json:"Condition"`
+}
+
+// policyStrings is a policy element that is either a string or an array of
+// them, the form Action and Resource both take.
+type policyStrings []string
+
+// UnmarshalJSONFrom implements json.UnmarshalerFrom.
+func (p *policyStrings) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	if dec.PeekKind() == '"' {
+		var single string
+		if err := json.UnmarshalDecode(dec, &single); err != nil {
+			return err
+		}
+		*p = policyStrings{single}
+		return nil
+	}
+	return json.UnmarshalDecode(dec, (*[]string)(p))
+}
+
+// policyPrincipal is the Principal element: either "*" or an object keyed by
+// principal type, e.g. {"AWS": "*"}. Only whether it covers every caller
+// matters, so an unsupported principal decodes to false rather than erroring.
+type policyPrincipal bool
+
+// UnmarshalJSONFrom implements json.UnmarshalerFrom.
+func (p *policyPrincipal) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	if dec.PeekKind() == '"' {
+		var single string
+		if err := json.UnmarshalDecode(dec, &single); err != nil {
+			return err
+		}
+		*p = policyPrincipal(single == policyWildcard)
+		return nil
+	}
+	var byType map[string]policyStrings
+	if err := json.UnmarshalDecode(dec, &byType); err != nil {
+		return err
+	}
+	aws := byType["AWS"]
+	*p = policyPrincipal(len(byType) == 1 && len(aws) == 1 && aws[0] == policyWildcard)
+	return nil
+}
+
+// parseBucketPolicy reads and validates a bucket policy for the named bucket,
+// returning the actions it grants anonymously.
+//
+// A document is accepted only when every statement allows actions from
+// [supportedPolicyActions] to everyone. Anything that would narrow, invert or
+// widen such a grant is rejected rather than ignored, which would grant more
+// than the document describes: [s3errs.ErrMalformedPolicy] if it is
+// structurally wrong or names another bucket, [s3errs.ErrNotImplemented] if it
+// is valid but expresses access s3d cannot represent.
+func parseBucketPolicy(bucket string, body io.Reader) (BucketPolicy, error) {
+	// read one byte past the limit so an oversized document is reported as such
+	// rather than truncated into a malformed one
+	document, err := io.ReadAll(io.LimitReader(body, maxPolicySize+1))
+	if err != nil {
+		return BucketPolicy{}, err
+	} else if len(document) > maxPolicySize {
+		return BucketPolicy{}, s3errs.ErrPolicyTooLarge
+	}
+
+	// json/v2 rejects duplicate member names and trailing content, neither of
+	// which v1 catches: keeping the last of two "Effect" members would read a
+	// document containing a deny as a plain allow
+	var doc policyDocument
+	if err := json.Unmarshal(document, &doc, json.RejectUnknownMembers(true)); err != nil {
+		return BucketPolicy{}, s3errs.ErrMalformedPolicy
+	} else if doc.Version != policyVersion || len(doc.Statement) == 0 {
+		return BucketPolicy{}, s3errs.ErrMalformedPolicy
+	}
+
+	bucketARN := policyARNPrefix + bucket
+	objectsARN := bucketARN + "/*"
+
+	var granted PolicyActions
+	for _, stmt := range doc.Statement {
+		switch {
+		case stmt.NotPrincipal != nil, stmt.NotAction != nil,
+			stmt.NotResource != nil, stmt.Condition != nil:
+			// each of these restricts or inverts the grant
+			return BucketPolicy{}, s3errs.ErrNotImplemented
+		case stmt.Effect == policyEffectDeny:
+			return BucketPolicy{}, s3errs.ErrNotImplemented
+		case stmt.Effect != policyEffectAllow:
+			return BucketPolicy{}, s3errs.ErrMalformedPolicy
+		case !bool(stmt.Principal):
+			// a bucket has one owner and s3d has no other accounts or roles, so
+			// "everyone" is the only principal that can mean anything
+			return BucketPolicy{}, s3errs.ErrNotImplemented
+		case len(stmt.Action) == 0, len(stmt.Resource) == 0:
+			return BucketPolicy{}, s3errs.ErrMalformedPolicy
+		}
+
+		// the actions this statement's resources can carry
+		var allowed PolicyActions
+		for _, resource := range stmt.Resource {
+			switch resource {
+			case bucketARN:
+				allowed |= bucketActions
+			case objectsARN:
+				allowed |= objectActions
+			default:
+				if !strings.HasPrefix(resource, bucketARN+"/") {
+					// a bucket policy may not govern another bucket
+					return BucketPolicy{}, s3errs.ErrMalformedPolicy
+				}
+				// valid, but scopes the grant to part of the bucket; s3d records
+				// grants per bucket
+				return BucketPolicy{}, s3errs.ErrNotImplemented
+			}
+		}
+
+		for _, action := range stmt.Action {
+			a, ok := supportedPolicyActions[action]
+			if !ok {
+				return BucketPolicy{}, s3errs.ErrNotImplemented
+			}
+			// an action with no matching resource grants nothing, as in S3
+			granted |= a & allowed
+		}
+	}
+
+	return BucketPolicy{Document: string(document), Public: granted}, nil
+}
+
+// routeBucketPolicy operates on routes that contain '?policy' in the query
+// string.
+func (s *s3) routeBucketPolicy(w http.ResponseWriter, r *http.Request, accessKeyID *string, bucket string) error {
+	validatedKey, err := assertAuth(accessKeyID)
+	if err != nil {
+		return err
+	}
+	switch r.Method {
+	case http.MethodPut:
+		return s.putBucketPolicy(w, r, validatedKey, bucket)
+	case http.MethodGet:
+		return s.getBucketPolicy(w, r, validatedKey, bucket)
+	case http.MethodDelete:
+		return s.deleteBucketPolicy(w, r, validatedKey, bucket)
+	default:
+		return s3errs.ErrMethodNotAllowed
+	}
+}
+
+// putBucketPolicy handles PUT Bucket policy requests.
+//
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketPolicy.html
+func (s *s3) putBucketPolicy(w http.ResponseWriter, r *http.Request, accessKeyID, bucket string) error {
+	s.logger.Debug("putting bucket policy", zap.String("bucket", bucket))
+
+	policy, err := parseBucketPolicy(bucket, r.Body)
+	if err != nil {
+		return err
+	}
+	if err := s.backend.PutBucketPolicy(r.Context(), accessKeyID, bucket, policy); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
+// getBucketPolicy handles GET Bucket policy requests.
+//
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicy.html
+func (s *s3) getBucketPolicy(w http.ResponseWriter, r *http.Request, accessKeyID, bucket string) error {
+	s.logger.Debug("getting bucket policy", zap.String("bucket", bucket))
+
+	policy, err := s.backend.GetBucketPolicy(r.Context(), accessKeyID, bucket)
+	if err != nil {
+		return err
+	}
+	// unlike most S3 responses this one is JSON
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = io.WriteString(w, policy.Document)
+	return err
+}
+
+// deleteBucketPolicy handles DELETE Bucket policy requests.
+//
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketPolicy.html
+func (s *s3) deleteBucketPolicy(w http.ResponseWriter, r *http.Request, accessKeyID, bucket string) error {
+	s.logger.Debug("deleting bucket policy", zap.String("bucket", bucket))
+
+	if err := s.backend.DeleteBucketPolicy(r.Context(), accessKeyID, bucket); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
+// routeBucketPolicyStatus operates on routes that contain '?policyStatus' in
+// the query string.
+func (s *s3) routeBucketPolicyStatus(w http.ResponseWriter, r *http.Request, accessKeyID *string, bucket string) error {
+	validatedKey, err := assertAuth(accessKeyID)
+	if err != nil {
+		return err
+	} else if r.Method != http.MethodGet {
+		return s3errs.ErrMethodNotAllowed
+	}
+	s.logger.Debug("getting bucket policy status", zap.String("bucket", bucket))
+
+	policy, err := s.backend.GetBucketPolicy(r.Context(), validatedKey, bucket)
+	if errors.Is(err, s3errs.ErrNoSuchBucketPolicy) {
+		// no policy is a status, not an error: the bucket is simply not public
+		policy = BucketPolicy{}
+	} else if err != nil {
+		return err
+	}
+	return writeXMLResponse(w, http.StatusOK, PolicyStatus{
+		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+		IsPublic: policy.Public != 0,
+	})
+}

--- a/s3/policy.go
+++ b/s3/policy.go
@@ -68,11 +68,15 @@ func (a PolicyActions) Allows(want PolicyActions) bool {
 	return want != 0 && a&want == want
 }
 
+// supportedPolicyActions is keyed by lowercase name: AWS treats the service
+// prefix and the action name as case insensitive.
+//
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html
 var supportedPolicyActions = map[string]PolicyActions{
-	"s3:GetObject":          ActionGetObject,
-	"s3:GetObjectVersion":   ActionGetObjectVersion,
-	"s3:ListBucket":         ActionListBucket,
-	"s3:ListBucketVersions": ActionListBucketVersions,
+	"s3:getobject":          ActionGetObject,
+	"s3:getobjectversion":   ActionGetObjectVersion,
+	"s3:listbucket":         ActionListBucket,
+	"s3:listbucketversions": ActionListBucketVersions,
 }
 
 // BucketPolicy is a bucket policy accepted by [parseBucketPolicy].
@@ -123,11 +127,11 @@ func (p *policyStatements) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 //
 // nolint:tagliatelle
 type policyStatement struct {
-	Sid       string          `json:"Sid"`
-	Effect    string          `json:"Effect"`
-	Principal policyPrincipal `json:"Principal"`
-	Action    policyStrings   `json:"Action"`
-	Resource  policyStrings   `json:"Resource"`
+	Sid       string           `json:"Sid"`
+	Effect    string           `json:"Effect"`
+	Principal *policyPrincipal `json:"Principal"`
+	Action    policyStrings    `json:"Action"`
+	Resource  policyStrings    `json:"Resource"`
 
 	NotPrincipal jsontext.Value `json:"NotPrincipal"`
 	NotAction    jsontext.Value `json:"NotAction"`
@@ -219,7 +223,10 @@ func parseBucketPolicy(bucket string, body io.Reader) (BucketPolicy, error) {
 			return BucketPolicy{}, s3errs.ErrNotImplemented
 		case stmt.Effect != policyEffectAllow:
 			return BucketPolicy{}, s3errs.ErrMalformedPolicy
-		case !bool(stmt.Principal):
+		case stmt.Principal == nil:
+			// a resource policy must say who it grants to
+			return BucketPolicy{}, s3errs.ErrMalformedPolicy
+		case !bool(*stmt.Principal):
 			// a bucket has one owner and s3d has no other accounts or roles, so
 			// "everyone" is the only principal that can mean anything
 			return BucketPolicy{}, s3errs.ErrNotImplemented
@@ -247,7 +254,7 @@ func parseBucketPolicy(bucket string, body io.Reader) (BucketPolicy, error) {
 		}
 
 		for _, action := range stmt.Action {
-			a, ok := supportedPolicyActions[action]
+			a, ok := supportedPolicyActions[strings.ToLower(action)]
 			if !ok {
 				return BucketPolicy{}, s3errs.ErrNotImplemented
 			}

--- a/s3/policy_test.go
+++ b/s3/policy_test.go
@@ -1,0 +1,397 @@
+package s3
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SiaFoundation/s3d/s3/s3errs"
+)
+
+func TestParseBucketPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   PolicyActions
+		err    error
+	}{
+		{
+			name: "canonical public read",
+			policy: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicRead",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::bucket/*"
+    }
+  ]
+}`,
+			want: ActionGetObject,
+		},
+		{
+			// AWS allows Statement as a single object, not only an array
+			name: "single statement object",
+			policy: `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}}`,
+			want: ActionGetObject,
+		},
+		{
+			name: "principal as AWS object",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+				"Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			want: ActionGetObject,
+		},
+		{
+			name: "principal as AWS array",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+				"Principal":{"AWS":["*"]},"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			want: ActionGetObject,
+		},
+		{
+			name: "action and resource as arrays",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":["s3:GetObject"],"Resource":["arn:aws:s3:::bucket/*"]}]}`,
+			want: ActionGetObject,
+		},
+		{
+			name: "two equivalent statements",
+			policy: `{"Version":"2012-10-17","Statement":[
+				{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"},
+				{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			want: ActionGetObject,
+		},
+		{
+			name: "versioned read",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":["s3:GetObject","s3:GetObjectVersion"],"Resource":"arn:aws:s3:::bucket/*"}]}`,
+			want: ActionGetObject | ActionGetObjectVersion,
+		},
+		{
+			// s3:ListBucket is granted on the bucket ARN, without the "/*"
+			name: "list bucket",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:ListBucket","Resource":"arn:aws:s3:::bucket"}]}`,
+			want: ActionListBucket,
+		},
+		{
+			name: "list object versions",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":["s3:ListBucket","s3:ListBucketVersions"],"Resource":"arn:aws:s3:::bucket"}]}`,
+			want: ActionListBucket | ActionListBucketVersions,
+		},
+		{
+			name: "read and list as separate statements",
+			policy: `{"Version":"2012-10-17","Statement":[
+				{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"},
+				{"Effect":"Allow","Principal":"*","Action":"s3:ListBucket","Resource":"arn:aws:s3:::bucket"}]}`,
+			want: ActionGetObject | ActionListBucket,
+		},
+		{
+			// one statement naming both resources pairs each action with its own
+			name: "read and list in one statement",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":["s3:GetObject","s3:GetObjectVersion","s3:ListBucket","s3:ListBucketVersions"],
+				"Resource":["arn:aws:s3:::bucket","arn:aws:s3:::bucket/*"]}]}`,
+			want: ActionGetObject | ActionGetObjectVersion | ActionListBucket | ActionListBucketVersions,
+		},
+		{
+			// an object action with no object resource grants nothing, as in S3
+			name: "object action with only the bucket resource",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket"}]}`,
+			want: 0,
+		},
+		{
+			name: "bucket action with only the object resource",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:ListBucket","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			want: 0,
+		},
+
+		// malformed documents
+		{
+			name:   "not json",
+			policy: `not a policy`,
+			err:    s3errs.ErrMalformedPolicy,
+		},
+		{
+			name:   "empty",
+			policy: ``,
+			err:    s3errs.ErrMalformedPolicy,
+		},
+		{
+			name:   "no statements",
+			policy: `{"Version":"2012-10-17","Statement":[]}`,
+			err:    s3errs.ErrMalformedPolicy,
+		},
+		{
+			// a misspelled restriction must not be dropped, which would turn
+			// this into the unconditional grant it only looks like
+			name: "misspelled condition",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*",
+				"Conditions":{"IpAddress":{"aws:SourceIp":"10.0.0.0/8"}}}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "unknown statement member",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*","Ttl":60}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "unknown statement member in the single-object form",
+			policy: `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*",
+				"Conditions":{"IpAddress":{"aws:SourceIp":"10.0.0.0/8"}}}}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "unknown document member",
+			policy: `{"Version":"2012-10-17","Statements":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			// json keeps the last value, so this must not read as a plain allow
+			name: "duplicate effect hiding a deny",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Effect":"Allow",
+				"Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "duplicate principal",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+				"Principal":{"AWS":"arn:aws:iam::111122223333:root"},"Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "duplicate action",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:PutObject","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "duplicate resource",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::other/*","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "duplicate document member",
+			policy: `{"Version":"2008-10-17","Version":"2012-10-17","Statement":[{"Effect":"Allow",
+				"Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			// nested objects are checked too, though a Condition is rejected anyway
+			name: "duplicate member inside a condition",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*",
+				"Condition":{"IpAddress":{"a":"1"},"IpAddress":{"b":"2"}}}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "trailing closing brace",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "trailing closing bracket",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}]`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "trailing content",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]} {"extra":1}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name:   "statement is not an object or array",
+			policy: `{"Version":"2012-10-17","Statement":"nonsense"}`,
+			err:    s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "missing version",
+			policy: `{"Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "legacy version",
+			policy: `{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "unknown effect",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Maybe","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "missing action",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "missing resource",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "resource names another bucket",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::other/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "resource names a bucket with a matching prefix",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket-two/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+
+		// valid policies expressing access s3d cannot represent; accepting one as
+		// a plain read grant would allow more than it says
+		{
+			name: "deny statement",
+			policy: `{"Version":"2012-10-17","Statement":[
+				{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"},
+				{"Effect":"Deny","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/secret/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "condition",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*",
+				"Condition":{"IpAddress":{"aws:SourceIp":"10.0.0.0/8"}}}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "not action",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"NotAction":"s3:DeleteObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "not principal",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+				"NotPrincipal":{"AWS":"arn:aws:iam::111122223333:root"},
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "not resource",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","NotResource":"arn:aws:s3:::bucket/secret/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "named principal",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+				"Principal":{"AWS":"arn:aws:iam::111122223333:root"},
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "service principal",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+				"Principal":{"Service":"cloudfront.amazonaws.com"},
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "wildcard action",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:*","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "write action",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":["s3:GetObject","s3:PutObject"],"Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+		{
+			name: "prefix scoped resource",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/public/*"}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, err := parseBucketPolicy("bucket", strings.NewReader(test.policy))
+			if test.err != nil {
+				if !errors.Is(err, test.err) {
+					t.Fatalf("expected %v, got %v", test.err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			} else if policy.Public != test.want {
+				t.Fatalf("expected actions %b, got %b", test.want, policy.Public)
+			} else if policy.Document != test.policy {
+				t.Fatalf("expected document to be stored verbatim, got %q", policy.Document)
+			}
+		})
+	}
+}
+
+// TestParseBucketPolicyTooLarge checks that an oversized document is reported
+// as such rather than truncated into a malformed one.
+func TestParseBucketPolicyTooLarge(t *testing.T) {
+	// pad the Sid past the limit, keeping the document valid JSON
+	padding := strings.Repeat("a", maxPolicySize)
+	policy := `{"Version":"2012-10-17","Statement":[{"Sid":"` + padding + `","Effect":"Allow",
+		"Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`
+
+	if _, err := parseBucketPolicy("bucket", strings.NewReader(policy)); !errors.Is(err, s3errs.ErrPolicyTooLarge) {
+		t.Fatalf("expected %v, got %v", s3errs.ErrPolicyTooLarge, err)
+	}
+}
+
+func TestPolicyActionsAllows(t *testing.T) {
+	granted := ActionGetObject | ActionListBucket
+
+	tests := []struct {
+		name string
+		want PolicyActions
+		ok   bool
+	}{
+		{"granted", ActionGetObject, true},
+		{"other granted", ActionListBucket, true},
+		{"both granted", ActionGetObject | ActionListBucket, true},
+		{"not granted", ActionGetObjectVersion, false},
+		{"one of two not granted", ActionGetObject | ActionGetObjectVersion, false},
+		// an empty set is contained in every set, so allowing it would
+		// authorize a caller that named no action against any policy
+		{"no action", 0, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := granted.Allows(test.want); got != test.ok {
+				t.Fatalf("expected %v, got %v", test.ok, got)
+			}
+		})
+	}
+
+	// including against a policy that grants nothing
+	var none PolicyActions
+	if none.Allows(0) {
+		t.Fatal("expected an empty want to be denied by an empty grant")
+	}
+}

--- a/s3/policy_test.go
+++ b/s3/policy_test.go
@@ -39,6 +39,19 @@ func TestParseBucketPolicy(t *testing.T) {
 			want: ActionGetObject,
 		},
 		{
+			// AWS treats the service prefix and action name as case insensitive
+			name: "action in a different case",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"S3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			want: ActionGetObject,
+		},
+		{
+			name: "action in lower case",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:listbucket","Resource":"arn:aws:s3:::bucket"}]}`,
+			want: ActionListBucket,
+		},
+		{
 			name: "principal as AWS object",
 			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
 				"Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
@@ -233,6 +246,12 @@ func TestParseBucketPolicy(t *testing.T) {
 		{
 			name: "unknown effect",
 			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Maybe","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
+			err: s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "missing principal",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
 				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*"}]}`,
 			err: s3errs.ErrMalformedPolicy,
 		},

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -113,10 +113,14 @@ type Backend interface {
 	// upload is retrieved, this can not be combined with a byte range.
 	//
 	// - If the access key does not have permission to access the object,
-	//   [ErrAccessDenied] must be returned. A 'nil' accessKeyID indicates the
-	//   anonymous user.
+	//   [ErrAccessDenied] must be returned, unless the bucket's policy grants
+	//   the action the request needs to everyone: s3:GetObjectVersion when it
+	//   names a version, s3:GetObject otherwise. A 'nil' accessKeyID indicates
+	//   the anonymous user.
 	//
-	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
+	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned, except
+	//   to an anonymous caller, which gets [ErrAccessDenied] so it cannot probe
+	//   for buckets it may not read.
 	//
 	// - If the object with the given key in the specified bucket does not exist,
 	//   [ErrNoSuchKey] must be returned.
@@ -153,9 +157,13 @@ type Backend interface {
 	// CommonPrefixes fields of the returned ObjectsListResult.
 	//
 	// - If the access key does not have permission to list objects in the bucket,
-	//   [ErrAccessDenied] must be returned.
+	//   [ErrAccessDenied] must be returned, unless the bucket's policy grants
+	//   s3:ListBucket to everyone. A 'nil' accessKeyID indicates the
+	//   anonymous user.
 	//
-	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
+	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned, except
+	//   to an anonymous caller, which gets [ErrAccessDenied] so it cannot probe
+	//   for buckets it may not read.
 	ListObjects(ctx context.Context, accessKeyID *string, bucket string, prefix Prefix, page ListObjectsPage) (*ObjectsListResult, error)
 
 	// PutObject puts an object with the given key into the specified bucket.
@@ -313,6 +321,36 @@ type Backend interface {
 	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
 	DeleteBucketLifecycleConfiguration(ctx context.Context, accessKeyID, bucket string) error
 
+	// PutBucketPolicy sets the policy for the specified bucket, replacing any
+	// existing policy. The policy is already validated; the backend stores it
+	// and honors [BucketPolicy.Public] on subsequent reads.
+	//
+	// - If the access key does not have permission to configure the bucket,
+	//   [ErrAccessDenied] must be returned.
+	//
+	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
+	PutBucketPolicy(ctx context.Context, accessKeyID, bucket string, policy BucketPolicy) error
+
+	// GetBucketPolicy returns the policy of the specified bucket, its document
+	// exactly as supplied to PutBucketPolicy.
+	//
+	// - If the access key does not have permission to read the bucket
+	//   configuration, [ErrAccessDenied] must be returned.
+	//
+	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
+	//
+	// - If the bucket has no policy, [ErrNoSuchBucketPolicy] must be returned.
+	GetBucketPolicy(ctx context.Context, accessKeyID, bucket string) (BucketPolicy, error)
+
+	// DeleteBucketPolicy removes the policy of the specified bucket, revoking
+	// any anonymous access. It is not an error if no policy exists.
+	//
+	// - If the access key does not have permission to configure the bucket,
+	//   [ErrAccessDenied] must be returned.
+	//
+	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
+	DeleteBucketPolicy(ctx context.Context, accessKeyID, bucket string) error
+
 	// PutBucketVersioning sets the versioning state of the specified bucket.
 	// status is either "Enabled" or "Suspended".
 	//
@@ -336,9 +374,13 @@ type Backend interface {
 	// objects in the specified bucket.
 	//
 	// - If the access key does not have permission to list the bucket,
-	//   [ErrAccessDenied] must be returned.
+	//   [ErrAccessDenied] must be returned, unless the bucket's policy grants
+	//   s3:ListBucketVersions to everyone. A 'nil' accessKeyID indicates the
+	//   anonymous user.
 	//
-	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
+	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned, except
+	//   to an anonymous caller, which gets [ErrAccessDenied] so it cannot probe
+	//   for buckets it may not read.
 	ListObjectVersions(ctx context.Context, accessKeyID *string, bucket string, prefix Prefix, page ListObjectVersionsPage) (*ObjectVersionsListResult, error)
 
 	// UploadStats returns statistics about the background upload pipeline.

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -32,7 +32,9 @@ type Backend interface {
 	//
 	// - If the source bucket does not exist, [ErrNoSuchBucket] must be returned.
 	//
-	// - If the source object does not exist, [ErrNoSuchKey] must be returned.
+	// - If the source object does not exist, [ErrNoSuchKey] must be returned,
+	//   or [ErrAccessDenied] when the caller reaches the source bucket through a
+	//   policy that does not grant s3:ListBucket.
 	//
 	// - If the destination bucket does not exist, [ErrNoSuchBucket] must be returned.
 	//
@@ -123,7 +125,10 @@ type Backend interface {
 	//   for buckets it may not read.
 	//
 	// - If the object with the given key in the specified bucket does not exist,
-	//   [ErrNoSuchKey] must be returned.
+	//   [ErrNoSuchKey] must be returned. A caller reaching the bucket through a
+	//   policy that does not grant s3:ListBucket gets [ErrAccessDenied] instead,
+	//   for a missing key, a missing version, or a current version that is a
+	//   delete marker, so it cannot enumerate the bucket by probing keys.
 	//
 	// - If the requested range is not satisfiable, [ErrInvalidRange] must be
 	//   returned. You can use the 'Range' method on 'rnge' for that.
@@ -244,7 +249,9 @@ type Backend interface {
 	// - If either the source or destination bucket does not exist,
 	// [ErrNoSuchBucket] must be returned.
 	//
-	// - If the source object does not exist, [ErrNoSuchKey] must be returned.
+	// - If the source object does not exist, [ErrNoSuchKey] must be returned,
+	//   or [ErrAccessDenied] when the caller reaches the source bucket through a
+	//   policy that does not grant s3:ListBucket.
 	//
 	// - srcVersion selects the source version: an unspecified request copies the
 	//   current version ([ErrNoSuchKey] if it is a delete marker), a specified

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
+	"encoding/json/v2"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -81,7 +81,7 @@ func TestUploadStats(t *testing.T) {
 	}
 
 	var stats s3.UploadStats
-	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+	if err := json.UnmarshalRead(resp.Body, &stats); err != nil {
 		t.Fatal(err)
 	} else if (stats != s3.UploadStats{}) {
 		t.Fatal("expected zero-value stats on an empty backend", stats)

--- a/s3/s3errs/errors.go
+++ b/s3/s3errs/errors.go
@@ -103,7 +103,7 @@ var (
 	ErrMalformedACLError                              = Error{"MalformedACLError", "Provided ACL is not well-formed or fails schema validation.", http.StatusBadRequest}
 	ErrMalformedPOSTRequest                           = Error{"MalformedPOSTRequest", "POST body is not well-formed multipart/form-data.", http.StatusBadRequest}
 	ErrMalformedXML                                   = Error{"MalformedXML", "Provided XML is not well-formed or fails schema validation.", http.StatusBadRequest}
-	ErrMalformedPolicy                                = Error{"MalformedPolicy", "Your policy contains a principal that is not valid.", http.StatusBadRequest}
+	ErrMalformedPolicy                                = Error{"MalformedPolicy", "The policy document is not valid.", http.StatusBadRequest}
 	ErrMaxMessageLengthExceeded                       = Error{"MaxMessageLengthExceeded", "Request was too large.", http.StatusBadRequest}
 	ErrMaxPostPreDataLengthExceededError              = Error{"MaxPostPreDataLengthExceededError", "POST fields preceding the file were too large.", http.StatusBadRequest}
 	ErrMetadataTooLarge                               = Error{"MetadataTooLarge", "Metadata headers exceed the maximum allowed size.", http.StatusBadRequest}
@@ -138,6 +138,7 @@ var (
 	ErrOwnershipControlsNotFoundError                 = Error{"OwnershipControlsNotFoundError", "Bucket ownership controls were not found.", http.StatusNotFound}
 	ErrPermanentRedirect                              = Error{"PermanentRedirect", "Use the specified endpoint; send future requests to that endpoint.", http.StatusMovedPermanently}
 	ErrPermanentRedirectControlError                  = Error{"PermanentRedirectControlError", "Operation must be addressed using the specified endpoint; redirect future requests accordingly.", http.StatusMovedPermanently}
+	ErrPolicyTooLarge                                 = Error{"PolicyTooLarge", "The policy exceeds the maximum allowed document size.", http.StatusBadRequest}
 	ErrPreconditionFailed                             = Error{"PreconditionFailed", "At least one specified precondition did not hold.", http.StatusPreconditionFailed}
 	ErrRedirect                                       = Error{"Redirect", "Temporary redirect while DNS is being updated.", http.StatusTemporaryRedirect}
 	ErrRequestHeaderSectionTooLarge                   = Error{"RequestHeaderSectionTooLarge", "Request header and query parameters exceed the maximum allowed size.", http.StatusBadRequest}

--- a/sia/buckets.go
+++ b/sia/buckets.go
@@ -30,6 +30,21 @@ func (s *Sia) ListBuckets(ctx context.Context, accessKeyID string) ([]s3.BucketI
 	return s.store.ListBuckets(accessKeyID)
 }
 
+// PutBucketPolicy sets the policy of the bucket, replacing any existing one.
+func (s *Sia) PutBucketPolicy(ctx context.Context, accessKeyID, bucket string, policy s3.BucketPolicy) error {
+	return s.store.PutBucketPolicy(accessKeyID, bucket, policy)
+}
+
+// GetBucketPolicy returns the policy of the bucket.
+func (s *Sia) GetBucketPolicy(ctx context.Context, accessKeyID, bucket string) (s3.BucketPolicy, error) {
+	return s.store.GetBucketPolicy(accessKeyID, bucket)
+}
+
+// DeleteBucketPolicy removes the policy of the bucket.
+func (s *Sia) DeleteBucketPolicy(ctx context.Context, accessKeyID, bucket string) error {
+	return s.store.DeleteBucketPolicy(accessKeyID, bucket)
+}
+
 // PutBucketVersioning sets the versioning state of the bucket.
 func (s *Sia) PutBucketVersioning(ctx context.Context, accessKeyID, bucket, status string) error {
 	return s.store.PutBucketVersioning(accessKeyID, bucket, status)

--- a/sia/multipart.go
+++ b/sia/multipart.go
@@ -204,7 +204,7 @@ func (s *Sia) UploadPartCopy(ctx context.Context, accessKeyID, srcBucket, srcObj
 	// fetch source object metadata (the requested version, or the current
 	// version when unspecified). The source is resolved first so a bad copy
 	// source is reported as such rather than as a missing upload.
-	obj, err := s.store.GetObject(accessKeyID, srcBucket, srcObject, srcVersion, nil)
+	obj, err := s.store.GetObject(&accessKeyID, srcBucket, srcObject, srcVersion, nil, s3.ReadAction(srcVersion))
 	if err != nil {
 		return nil, err
 	}

--- a/sia/multipart_test.go
+++ b/sia/multipart_test.go
@@ -549,7 +549,7 @@ func TestMultipartUpload(t *testing.T) {
 	}
 
 	// verify the completed object references the upload directory
-	obj, err := store.GetObject(testutil.AccessKeyID, bucket, object, s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,7 +581,7 @@ func TestMultipartUpload(t *testing.T) {
 	backend.PinObjects(t.Context())
 
 	// verify the object is now on Sia
-	obj, err = store.GetObject(testutil.AccessKeyID, bucket, object, s3.NoVersion(), nil)
+	obj, err = store.GetObject(aws.String(testutil.AccessKeyID), bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -311,11 +311,11 @@ func (s *Sia) HeadObject(ctx context.Context, accessKeyID *string, bucket, objec
 }
 
 func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, object string, version s3.VersionRequest, requestedRange *s3.ObjectRangeRequest, partNumber *int32, head bool) (*s3.Object, error) {
-	if accessKeyID == nil {
-		return nil, s3errs.ErrAccessDenied
-	}
+	// decided once so the retry below stays authorized as the read the client
+	// asked for, not as a versioned one
+	action := s3.ReadAction(version)
 
-	obj, err := s.store.GetObject(*accessKeyID, bucket, object, version, partNumber)
+	obj, err := s.store.GetObject(accessKeyID, bucket, object, version, partNumber, action)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 			// the upload loop moved the file to Sia between our GetObject
 			// and file open, re-fetch the same version to get the updated
 			// metadata and retry
-			obj, err = s.store.GetObject(*accessKeyID, bucket, object, s3.SpecificVersion(obj.VersionID), partNumber)
+			obj, err = s.store.GetObject(accessKeyID, bucket, object, s3.SpecificVersion(obj.VersionID), partNumber, action)
 			if err != nil {
 				return nil, err
 			} else if obj.FileName != nil {
@@ -408,25 +408,10 @@ func (s *Sia) headOrGetObject(ctx context.Context, accessKeyID *string, bucket, 
 // contents of the bucket and sort the results into the Contents and
 // CommonPrefixes fields of the returned ObjectsListResult.
 func (s *Sia) ListObjects(ctx context.Context, accessKeyID *string, bucket string, prefix s3.Prefix, page s3.ListObjectsPage) (*s3.ObjectsListResult, error) {
-	if accessKeyID == nil {
-		// anonymous access is not supported yet
-		return nil, s3errs.ErrAccessDenied
-	}
-
-	result, err := s.store.ListObjects(*accessKeyID, bucket, prefix, page)
+	// the store rejects an anonymous list unless the policy grants s3:ListBucket
+	result, err := s.store.ListObjects(accessKeyID, bucket, prefix, page)
 	if err != nil {
 		return nil, err
-	}
-
-	// populate owner info if requested
-	if page.FetchOwner != nil && *page.FetchOwner {
-		owner, err := s.UserInfo(ctx, *accessKeyID)
-		if err != nil {
-			return nil, err
-		}
-		for i := range result.Contents {
-			result.Contents[i].Owner = owner
-		}
 	}
 	return result, nil
 }
@@ -435,26 +420,13 @@ func (s *Sia) ListObjects(ctx context.Context, accessKeyID *string, bucket strin
 // objects in the specified bucket for the user identified by the given access
 // key.
 func (s *Sia) ListObjectVersions(ctx context.Context, accessKeyID *string, bucket string, prefix s3.Prefix, page s3.ListObjectVersionsPage) (*s3.ObjectVersionsListResult, error) {
-	if accessKeyID == nil {
-		// anonymous access is not supported yet
-		return nil, s3errs.ErrAccessDenied
-	}
-
-	result, err := s.store.ListObjectVersions(*accessKeyID, bucket, prefix, page)
+	// the store rejects an anonymous list unless the policy grants
+	// s3:ListBucketVersions
+	result, err := s.store.ListObjectVersions(accessKeyID, bucket, prefix, page)
 	if err != nil {
 		return nil, err
 	}
 
-	// populate owner info if requested
-	if page.FetchOwner != nil && *page.FetchOwner {
-		owner, err := s.UserInfo(ctx, *accessKeyID)
-		if err != nil {
-			return nil, err
-		}
-		for i := range result.Versions {
-			result.Versions[i].Owner = owner
-		}
-	}
 	return result, nil
 }
 
@@ -465,7 +437,7 @@ func (s *Sia) checkWritePreconditions(accessKeyID, bucket, object string, p s3.O
 	if !p.HasWritePreconditions() {
 		return nil
 	}
-	obj, err := s.store.GetObject(accessKeyID, bucket, object, s3.NoVersion(), nil)
+	obj, err := s.store.GetObject(&accessKeyID, bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 	if errors.Is(err, s3errs.ErrNoSuchKey) {
 		return p.CheckWrite(nil)
 	} else if err != nil {

--- a/sia/objects_test.go
+++ b/sia/objects_test.go
@@ -280,7 +280,7 @@ func TestPutObject(t *testing.T) {
 		}
 
 		// verify the object is on disk
-		obj, err := store.GetObject(testutil.AccessKeyID, bucket, "pending", s3.NoVersion(), nil)
+		obj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, "pending", s3.NoVersion(), nil, s3.ActionGetObject)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -311,7 +311,7 @@ func TestPutObject(t *testing.T) {
 		backend.PinObjects(t.Context())
 
 		// verify the object is now on Sia
-		obj, err = store.GetObject(testutil.AccessKeyID, bucket, "pending", s3.NoVersion(), nil)
+		obj, err = store.GetObject(aws.String(testutil.AccessKeyID), bucket, "pending", s3.NoVersion(), nil, s3.ActionGetObject)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -348,7 +348,7 @@ func TestPutObject(t *testing.T) {
 		if _, err := s3Tester.PutObject(t.Context(), bucket, "blocked", bytes.NewReader(blocked), nil); err != nil {
 			t.Fatal(err)
 		}
-		blockedObj, err := store.GetObject(testutil.AccessKeyID, bucket, "blocked", s3.NoVersion(), nil)
+		blockedObj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, "blocked", s3.NoVersion(), nil, s3.ActionGetObject)
 		if err != nil {
 			t.Fatal(err)
 		} else if blockedObj.FileName == nil {
@@ -360,7 +360,7 @@ func TestPutObject(t *testing.T) {
 		backend.UploadObjects(t.Context())
 
 		// assert blocked object was not uploaded
-		blockedObj, err = store.GetObject(testutil.AccessKeyID, bucket, "blocked", s3.NoVersion(), nil)
+		blockedObj, err = store.GetObject(aws.String(testutil.AccessKeyID), bucket, "blocked", s3.NoVersion(), nil, s3.ActionGetObject)
 		if err != nil {
 			t.Fatal(err)
 		} else if blockedObj.FileName == nil {
@@ -377,7 +377,7 @@ func TestPutObject(t *testing.T) {
 		backend.PinObjects(t.Context())
 
 		// assert object was uploaded
-		blockedObj, err = store.GetObject(testutil.AccessKeyID, bucket, "blocked", s3.NoVersion(), nil)
+		blockedObj, err = store.GetObject(aws.String(testutil.AccessKeyID), bucket, "blocked", s3.NoVersion(), nil, s3.ActionGetObject)
 		if err != nil {
 			t.Fatal(err)
 		} else if blockedObj.FileName != nil {
@@ -394,7 +394,7 @@ func TestPutObject(t *testing.T) {
 		backend.PinObjects(t.Context())
 		memSDK.SetAccountErr(nil)
 
-		blockedObj, err = store.GetObject(testutil.AccessKeyID, bucket, "blocked", s3.NoVersion(), nil)
+		blockedObj, err = store.GetObject(aws.String(testutil.AccessKeyID), bucket, "blocked", s3.NoVersion(), nil, s3.ActionGetObject)
 		if err != nil {
 			t.Fatal(err)
 		} else if blockedObj.FileName != nil {
@@ -478,7 +478,7 @@ func TestFlushObjects(t *testing.T) {
 	}
 
 	// the object should now be served from Sia
-	obj, err := store.GetObject(testutil.AccessKeyID, bucket, "small", s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, "small", s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName != nil {
@@ -949,7 +949,7 @@ func TestSyncMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	obj, err := store.GetObject(testutil.AccessKeyID, bucket, "obj", s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, "obj", s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName == nil {
@@ -961,7 +961,7 @@ func TestSyncMetadata(t *testing.T) {
 	}
 
 	// record the original sealed object
-	origObj, err := store.GetObject(testutil.AccessKeyID, bucket, "obj", s3.NoVersion(), nil)
+	origObj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, "obj", s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -997,7 +997,7 @@ func TestSyncMetadata(t *testing.T) {
 	}
 
 	// the object's sia_object should have been re-sealed by the sync
-	objAfter, err := store.GetObject(testutil.AccessKeyID, bucket, "obj", s3.NoVersion(), nil)
+	objAfter, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, "obj", s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1114,7 +1114,7 @@ func TestOverwritePendingObjectCleansUpFile(t *testing.T) {
 	uploadsDir := filepath.Join(dir, sia.UploadsDirectory)
 	pendingFilename := func(t *testing.T, object string) string {
 		t.Helper()
-		obj, err := store.GetObject(testutil.AccessKeyID, bucket, object, s3.NoVersion(), nil)
+		obj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 		if err != nil {
 			t.Fatal(err)
 		} else if obj.FileName == nil {

--- a/sia/persist/sqlite/buckets.go
+++ b/sia/persist/sqlite/buckets.go
@@ -150,6 +150,103 @@ func bucketIDAndVersioning(tx *txn, accessKeyID, bucket string) (bid int64, stat
 	return bid, status, err
 }
 
+// PutBucketPolicy stores the bucket's policy, replacing any existing one.
+func (s *Store) PutBucketPolicy(accessKeyID, bucket string, policy s3.BucketPolicy) error {
+	return s.transaction(func(tx *txn) error {
+		bid, err := bucketID(tx, accessKeyID, bucket)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(`UPDATE buckets SET policy = $1, public_actions = $2 WHERE id = $3`, policy.Document, policy.Public, bid)
+		return err
+	})
+}
+
+// GetBucketPolicy returns the bucket's policy, or ErrNoSuchBucketPolicy if the
+// bucket has none.
+func (s *Store) GetBucketPolicy(accessKeyID, bucket string) (policy s3.BucketPolicy, err error) {
+	err = s.transaction(func(tx *txn) error {
+		bid, err := bucketID(tx, accessKeyID, bucket)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRow(`SELECT policy, public_actions FROM buckets WHERE id = $1`, bid).Scan(&policy.Document, &policy.Public)
+		if err != nil {
+			return err
+		} else if policy.Document == "" {
+			return s3errs.ErrNoSuchBucketPolicy
+		}
+		return nil
+	})
+	if err != nil {
+		return s3.BucketPolicy{}, err
+	}
+	return policy, nil
+}
+
+// DeleteBucketPolicy removes the bucket's policy. It is not an error if the
+// bucket has none.
+func (s *Store) DeleteBucketPolicy(accessKeyID, bucket string) error {
+	return s.transaction(func(tx *txn) error {
+		bid, err := bucketID(tx, accessKeyID, bucket)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(`UPDATE buckets SET policy = '', public_actions = 0 WHERE id = $1`, bid)
+		return err
+	})
+}
+
+// bucketRead is a bucket resolved for reading.
+type bucketRead struct {
+	id         int64
+	owner      string
+	versioning string
+}
+
+// userInfo returns the bucket's owner, which a listing reports in place of the
+// caller.
+func (b bucketRead) userInfo() *s3.UserInfo {
+	return &s3.UserInfo{ID: b.owner, DisplayName: b.owner}
+}
+
+// bucketForRead resolves a bucket for a read. The caller must own the bucket,
+// as in [bucketID], or its policy must grant action to everyone, which covers
+// signed requests from other users as well as unsigned ones. An anonymous
+// caller gets ErrAccessDenied whether or not the bucket exists, so it cannot
+// probe for private buckets.
+func bucketForRead(tx *txn, accessKeyID *string, bucket string, action s3.PolicyActions) (bucketRead, error) {
+	var b bucketRead
+	var ownerID int64
+	var granted s3.PolicyActions
+	err := tx.QueryRow(`
+		SELECT b.id, b.user_id, u.name, b.public_actions, b.versioning_status
+		FROM buckets b
+		INNER JOIN users u ON u.id = b.user_id
+		WHERE b.name = $1`, bucket).Scan(&b.id, &ownerID, &b.owner, &granted, &b.versioning)
+	if errors.Is(err, sql.ErrNoRows) {
+		if accessKeyID == nil {
+			return bucketRead{}, s3errs.ErrAccessDenied
+		}
+		return bucketRead{}, s3errs.ErrNoSuchBucket
+	} else if err != nil {
+		return bucketRead{}, err
+	}
+
+	if accessKeyID != nil {
+		uid, err := userIDForAccessKey(tx, *accessKeyID)
+		if err != nil {
+			return bucketRead{}, err
+		} else if ownerID == uid {
+			return b, nil
+		}
+	}
+	if !granted.Allows(action) {
+		return bucketRead{}, s3errs.ErrAccessDenied
+	}
+	return b, nil
+}
+
 // bucketID returns the ID of the bucket with the given name if the user
 // associated with the given access key owns it. Returns ErrNoSuchBucket if
 // the bucket does not exist, or ErrAccessDenied if it exists but is owned by

--- a/sia/persist/sqlite/buckets.go
+++ b/sia/persist/sqlite/buckets.go
@@ -202,6 +202,7 @@ type bucketRead struct {
 	id         int64
 	owner      string
 	versioning string
+	mayList    bool
 }
 
 // userInfo returns the bucket's owner, which a listing reports in place of the
@@ -238,12 +239,14 @@ func bucketForRead(tx *txn, accessKeyID *string, bucket string, action s3.Policy
 		if err != nil {
 			return bucketRead{}, err
 		} else if ownerID == uid {
+			b.mayList = true // the owner may always list
 			return b, nil
 		}
 	}
 	if !granted.Allows(action) {
 		return bucketRead{}, s3errs.ErrAccessDenied
 	}
+	b.mayList = granted.Allows(s3.ActionListBucket)
 	return b, nil
 }
 

--- a/sia/persist/sqlite/buckets_test.go
+++ b/sia/persist/sqlite/buckets_test.go
@@ -51,3 +51,23 @@ func TestSuspendedDeletePreconditionAgainstCurrentVersion(t *testing.T) {
 		t.Fatalf("expected a null delete marker, got versionID=%q isDeleteMarker=%v", versionID, isDeleteMarker)
 	}
 }
+
+// TestBucketForReadRejectsNoAction checks that a read naming no action is
+// denied. Every action set contains the empty one, so treating it as satisfied
+// would authorize any caller against any bucket.
+func TestBucketForReadRejectsNoAction(t *testing.T) {
+	const bucket = "test-bucket"
+	store := initTestDB(t, zaptest.NewLogger(t))
+	if err := store.CreateBucket(testAccessKeyID, bucket); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.PutObject(testAccessKeyID, bucket, "key", objects.PutOptions{ContentMD5: frand.Entropy128()}); err != nil {
+		t.Fatal(err)
+	}
+
+	// the bucket has no policy, so an anonymous read must be denied whatever
+	// action it names
+	if _, err := store.GetObject(nil, bucket, "key", s3.NoVersion(), nil, 0); !errors.Is(err, s3errs.ErrAccessDenied) {
+		t.Fatalf("expected %v, got %v", s3errs.ErrAccessDenied, err)
+	}
+}

--- a/sia/persist/sqlite/init.sql
+++ b/sia/persist/sqlite/init.sql
@@ -22,6 +22,8 @@ CREATE TABLE buckets (
     name TEXT NOT NULL UNIQUE,
     user_id INTEGER NOT NULL,
     versioning_status TEXT NOT NULL DEFAULT '' CHECK (versioning_status IN ('', 'Enabled', 'Suspended')),
+    policy TEXT NOT NULL DEFAULT '',
+    public_actions INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (user_id) REFERENCES users(id)
 );
 CREATE INDEX buckets_user_id_idx ON buckets(user_id);

--- a/sia/persist/sqlite/lifecycle_test.go
+++ b/sia/persist/sqlite/lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SiaFoundation/s3d/s3"
 	"github.com/SiaFoundation/s3d/s3/s3errs"
 	"github.com/SiaFoundation/s3d/sia/objects"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
@@ -208,11 +209,11 @@ func TestExpireObjectsVersions(t *testing.T) {
 	} else if len(orphans) != 0 {
 		t.Fatalf("expected no orphans, got %+v", orphans)
 	}
-	if obj, err := store.GetObject(accessKeyID, bucket, key, s3.NoVersion(), nil); err != nil {
+	if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.NoVersion(), nil, s3.ActionGetObject); err != nil {
 		t.Fatal(err)
 	} else if obj.VersionID != currentVersion {
 		t.Fatalf("expected current version %q, got %q", currentVersion, obj.VersionID)
-	} else if _, err := store.GetObject(accessKeyID, bucket, key, s3.SpecificVersion(oldVersion), nil); err != nil {
+	} else if _, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.SpecificVersion(oldVersion), nil, s3.ActionGetObject); err != nil {
 		t.Fatalf("expected old noncurrent version to remain, got %v", err)
 	}
 }

--- a/sia/persist/sqlite/migrations.go
+++ b/sia/persist/sqlite/migrations.go
@@ -352,4 +352,10 @@ INSERT INTO object_parts (bucket_id, name, version_id, part_number, filename, co
 DROP TABLE object_parts_backup;`)
 		return err
 	},
+	func(tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(`
+ALTER TABLE buckets ADD COLUMN policy TEXT NOT NULL DEFAULT '';
+ALTER TABLE buckets ADD COLUMN public_actions INTEGER NOT NULL DEFAULT 0;`)
+		return err
+	},
 }

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -173,17 +173,21 @@ func checkWritePreconditions(tx *txn, bid int64, name string, p s3.ObjectPrecond
 // GetObject retrieves an object. An unspecified version returns the current
 // version (ErrNoSuchKey if the key has no versions); a specified version returns
 // that version (ErrNoSuchVersion if absent). The result may be a delete marker.
-func (s *Store) GetObject(accessKeyID, bucket, name string, version s3.VersionRequest, partNumber *int32) (*objects.Object, error) {
+//
+// A nil accessKeyID is an anonymous read, which only succeeds when the bucket's
+// policy grants action. The caller picks action so that a read resolving a
+// version internally stays authorized by what the original request asked for.
+func (s *Store) GetObject(accessKeyID *string, bucket, name string, version s3.VersionRequest, partNumber *int32, action s3.PolicyActions) (*objects.Object, error) {
 	var obj objects.Object
 	if err := s.transaction(func(tx *txn) error {
-		bid, status, err := bucketIDAndVersioning(tx, accessKeyID, bucket)
+		b, err := bucketForRead(tx, accessKeyID, bucket, action)
 		if err != nil {
 			return err
 		}
-		if err := getObject(tx, &obj, bid, name, version, partNumber); err != nil {
+		if err := getObject(tx, &obj, b.id, name, version, partNumber); err != nil {
 			return err
 		}
-		obj.Versioned = status != ""
+		obj.Versioned = b.versioning != ""
 		return nil
 	}); errors.Is(err, sql.ErrNoRows) {
 		if version.Specified {
@@ -644,9 +648,23 @@ func (s *Store) CopyObject(accessKeyID, srcBucket, srcName string, srcVersion s3
 		obj = objects.Object{} // reset per transaction attempt
 		versionID, srcVersionWire, orphan = "", "", objects.OrphanedFile{}
 
-		srcBid, srcStatus, err := bucketIDAndVersioning(tx, accessKeyID, srcBucket)
+		// the destination is written, so it must be owned by the caller. It is
+		// resolved first so the same-bucket shortcut below can never inherit a
+		// bucket the caller only has read access to.
+		dstBid, dstStatus, err := bucketIDAndVersioning(tx, accessKeyID, dstBucket)
 		if err != nil {
 			return err
+		}
+
+		// the source is only read, so a policy granting that read is enough,
+		// matching UploadPartCopy
+		srcBid, srcStatus := dstBid, dstStatus
+		if srcBucket != dstBucket {
+			src, err := bucketForRead(tx, &accessKeyID, srcBucket, s3.ReadAction(srcVersion))
+			if err != nil {
+				return err
+			}
+			srcBid, srcStatus = src.id, src.versioning
 		}
 
 		// copy the requested source version, or the current version when
@@ -668,15 +686,6 @@ func (s *Store) CopyObject(accessKeyID, srcBucket, srcName string, srcVersion s3
 			maps.Copy(obj.Meta, opts.Meta)
 		}
 
-		// a same-bucket copy shares the source's id and versioning status, so
-		// only resolve the destination separately when the buckets differ.
-		dstBid, dstStatus := srcBid, srcStatus
-		if dstBucket != srcBucket {
-			dstBid, dstStatus, err = bucketIDAndVersioning(tx, accessKeyID, dstBucket)
-			if err != nil {
-				return err
-			}
-		}
 		if err := checkWritePreconditions(tx, dstBid, dstName, opts.DestinationPreconditions); err != nil {
 			return err
 		}
@@ -1107,11 +1116,8 @@ WHERE o.bucket_id = ?
 
 // ListObjects lists objects in the specified bucket, filtered by prefix and
 // pagination settings.
-func (s *Store) ListObjects(accessKeyID, bucket string, prefix s3.Prefix, page s3.ListObjectsPage) (result *s3.ObjectsListResult, err error) {
+func (s *Store) ListObjects(accessKeyID *string, bucket string, prefix s3.Prefix, page s3.ListObjectsPage) (result *s3.ObjectsListResult, err error) {
 	result = s3.NewObjectsListResult(page.MaxKeys)
-	if page.MaxKeys == 0 {
-		return result, nil
-	}
 
 	// adjust marker if it falls inside a common prefix
 	var marker string
@@ -1126,9 +1132,15 @@ func (s *Store) ListObjects(accessKeyID, bucket string, prefix s3.Prefix, page s
 	err = s.transaction(func(tx *txn) error {
 		*result = *s3.NewObjectsListResult(page.MaxKeys) // reset per transaction attempt
 
-		bid, err := bucketID(tx, accessKeyID, bucket)
+		b, err := bucketForRead(tx, accessKeyID, bucket, s3.ActionListBucket)
 		if err != nil {
 			return fmt.Errorf("failed to get bucket ID: %w", err)
+		}
+		bid := b.id
+
+		// a caller that asked for no keys still has to be allowed to list
+		if page.MaxKeys == 0 {
+			return nil
 		}
 
 		innerMarker := marker
@@ -1146,7 +1158,12 @@ func (s *Store) ListObjects(accessKeyID, bucket string, prefix s3.Prefix, page s
 		if !result.IsTruncated {
 			result.NextMarker = ""
 		}
-
+		if page.FetchOwner != nil && *page.FetchOwner {
+			owner := b.userInfo()
+			for i := range result.Contents {
+				result.Contents[i].Owner = owner
+			}
+		}
 		return nil
 	})
 	if err != nil {
@@ -1281,19 +1298,22 @@ func listVersionPage(tx *txn, bid int64, prefix s3.Prefix, m versionMarker, limi
 // objects in the bucket, ordered by key ascending then by version creation
 // order descending (newest first), applying prefix, delimiter and the
 // (key-marker, version-id-marker) cursor.
-func (s *Store) ListObjectVersions(accessKeyID, bucket string, prefix s3.Prefix, page s3.ListObjectVersionsPage) (*s3.ObjectVersionsListResult, error) {
+func (s *Store) ListObjectVersions(accessKeyID *string, bucket string, prefix s3.Prefix, page s3.ListObjectVersionsPage) (*s3.ObjectVersionsListResult, error) {
 	result := s3.NewObjectVersionsListResult(page.MaxKeys)
-	if page.MaxKeys == 0 {
-		return result, nil
-	}
 
 	const maxRowsPerQuery = 100
 	err := s.transaction(func(tx *txn) error {
 		*result = *s3.NewObjectVersionsListResult(page.MaxKeys) // reset per attempt
 
-		bid, err := bucketID(tx, accessKeyID, bucket)
+		b, err := bucketForRead(tx, accessKeyID, bucket, s3.ActionListBucketVersions)
 		if err != nil {
 			return err
+		}
+		bid := b.id
+
+		// a caller that asked for no keys still has to be allowed to list
+		if page.MaxKeys == 0 {
+			return nil
 		}
 
 		m, err := resolveVersionCursor(tx, bid, prefix, page)
@@ -1314,6 +1334,12 @@ func (s *Store) ListObjectVersions(accessKeyID, bucket string, prefix s3.Prefix,
 
 		if !result.IsTruncated {
 			result.NextKeyMarker, result.NextVersionIDMarker = "", ""
+		}
+		if page.FetchOwner != nil && *page.FetchOwner {
+			owner := b.userInfo()
+			for k := range result.Versions {
+				result.Versions[k].Owner = owner
+			}
 		}
 		return nil
 	})

--- a/sia/persist/sqlite/objects.go
+++ b/sia/persist/sqlite/objects.go
@@ -170,6 +170,13 @@ func checkWritePreconditions(tx *txn, bid int64, name string, p s3.ObjectPrecond
 	return p.CheckWrite(&attrs)
 }
 
+// hidesDeleteMarker reports whether a resolved object must be hidden from the
+// caller. A delete marker proves the key once existed, so a caller that may not
+// list the bucket must not be able to tell it apart from a key that never did.
+func hidesDeleteMarker(mayList bool, obj objects.Object, version s3.VersionRequest) bool {
+	return !mayList && obj.IsDeleteMarker && !version.Specified
+}
+
 // GetObject retrieves an object. An unspecified version returns the current
 // version (ErrNoSuchKey if the key has no versions); a specified version returns
 // that version (ErrNoSuchVersion if absent). The result may be a delete marker.
@@ -179,18 +186,25 @@ func checkWritePreconditions(tx *txn, bid int64, name string, p s3.ObjectPrecond
 // version internally stays authorized by what the original request asked for.
 func (s *Store) GetObject(accessKeyID *string, bucket, name string, version s3.VersionRequest, partNumber *int32, action s3.PolicyActions) (*objects.Object, error) {
 	var obj objects.Object
+	var mayList bool
 	if err := s.transaction(func(tx *txn) error {
 		b, err := bucketForRead(tx, accessKeyID, bucket, action)
 		if err != nil {
 			return err
 		}
+		mayList = b.mayList
 		if err := getObject(tx, &obj, b.id, name, version, partNumber); err != nil {
 			return err
+		}
+		if hidesDeleteMarker(mayList, obj, version) {
+			return s3errs.ErrAccessDenied
 		}
 		obj.Versioned = b.versioning != ""
 		return nil
 	}); errors.Is(err, sql.ErrNoRows) {
-		if version.Specified {
+		if !mayList {
+			return nil, s3errs.ErrAccessDenied
+		} else if version.Specified {
 			return nil, s3errs.ErrNoSuchVersion
 		}
 		return nil, s3errs.ErrNoSuchKey
@@ -644,6 +658,7 @@ func (s *Store) UpdateSiaObjects(siaObjects []objects.SiaObject) (updated int64,
 func (s *Store) CopyObject(accessKeyID, srcBucket, srcName string, srcVersion s3.VersionRequest, dstBucket, dstName string, opts s3.CopyObjectOptions) (_ *s3.CopyObjectResult, orphan objects.OrphanedFile, err error) {
 	var obj objects.Object
 	var versionID, srcVersionWire string
+	var srcMayList bool
 	err = s.transaction(func(tx *txn) error {
 		obj = objects.Object{} // reset per transaction attempt
 		versionID, srcVersionWire, orphan = "", "", objects.OrphanedFile{}
@@ -659,18 +674,22 @@ func (s *Store) CopyObject(accessKeyID, srcBucket, srcName string, srcVersion s3
 		// the source is only read, so a policy granting that read is enough,
 		// matching UploadPartCopy
 		srcBid, srcStatus := dstBid, dstStatus
+		srcMayList = true // a same-bucket copy is made by the bucket's owner
 		if srcBucket != dstBucket {
 			src, err := bucketForRead(tx, &accessKeyID, srcBucket, s3.ReadAction(srcVersion))
 			if err != nil {
 				return err
 			}
-			srcBid, srcStatus = src.id, src.versioning
+			srcBid, srcStatus, srcMayList = src.id, src.versioning, src.mayList
 		}
 
 		// copy the requested source version, or the current version when
 		// unspecified
 		if err := getObject(tx, &obj, srcBid, srcName, srcVersion, nil); err != nil {
 			return err
+		}
+		if hidesDeleteMarker(srcMayList, obj, srcVersion) {
+			return s3errs.ErrAccessDenied
 		}
 		if err := opts.SourcePreconditions.CheckCopySource(obj.Attrs(), srcVersion); err != nil {
 			return err
@@ -735,7 +754,9 @@ func (s *Store) CopyObject(accessKeyID, srcBucket, srcName string, srcVersion s3
 	if errors.Is(err, sql.ErrNoRows) {
 		// a missing source maps to ErrNoSuchVersion when a specific version was
 		// requested, otherwise ErrNoSuchKey.
-		if srcVersion.Specified {
+		if !srcMayList {
+			return nil, objects.OrphanedFile{}, s3errs.ErrAccessDenied
+		} else if srcVersion.Specified {
 			return nil, objects.OrphanedFile{}, s3errs.ErrNoSuchVersion
 		}
 		return nil, objects.OrphanedFile{}, s3errs.ErrNoSuchKey

--- a/sia/persist/sqlite/objects_test.go
+++ b/sia/persist/sqlite/objects_test.go
@@ -305,7 +305,7 @@ func TestGetObject(t *testing.T) {
 	}
 
 	// get object without part number
-	obj, err := store.GetObject(testAccessKeyID, bucket, object, s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testAccessKeyID), bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.SiaObject != nil {
@@ -324,7 +324,7 @@ func TestGetObject(t *testing.T) {
 	}
 
 	// re-fetch and verify the sia_object_id is now set
-	obj, err = store.GetObject(testAccessKeyID, bucket, object, s3.NoVersion(), nil)
+	obj, err = store.GetObject(aws.String(testAccessKeyID), bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.SiaObject == nil || obj.SiaObject.ID != objSealed.ID() {
@@ -332,7 +332,7 @@ func TestGetObject(t *testing.T) {
 	}
 
 	// get object with part number 1
-	objPart1, err := store.GetObject(testAccessKeyID, bucket, object, s3.NoVersion(), aws.Int32(1))
+	objPart1, err := store.GetObject(aws.String(testAccessKeyID), bucket, object, s3.NoVersion(), aws.Int32(1), s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if objPart1.SiaObject == nil || objPart1.SiaObject.ID != objSealed.ID() {
@@ -360,7 +360,7 @@ func TestGetObject(t *testing.T) {
 
 	// get multipart object with part number 2
 	mpID := multipartSealed.ID()
-	multipartPart2, err := store.GetObject(testAccessKeyID, bucket, multipart, s3.NoVersion(), aws.Int32(2))
+	multipartPart2, err := store.GetObject(aws.String(testAccessKeyID), bucket, multipart, s3.NoVersion(), aws.Int32(2), s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if multipartPart2.SiaObject == nil || multipartPart2.SiaObject.ID != mpID {
@@ -380,7 +380,7 @@ func TestGetObject(t *testing.T) {
 	}
 
 	// get object with invalid part number
-	_, err = store.GetObject(testAccessKeyID, bucket, object, s3.NoVersion(), aws.Int32(3))
+	_, err = store.GetObject(aws.String(testAccessKeyID), bucket, object, s3.NoVersion(), aws.Int32(3), s3.ActionGetObject)
 	if !errors.Is(err, s3errs.ErrInvalidPart) {
 		t.Fatal("unexpected error", err)
 	}
@@ -415,7 +415,7 @@ func TestGetObjectPartFields(t *testing.T) {
 	}
 
 	// pending multipart: fetching part 1 should populate FileName
-	obj, err := store.GetObject(accessKeyID, bucket, name, s3.NoVersion(), aws.Int32(1))
+	obj, err := store.GetObject(aws.String(accessKeyID), bucket, name, s3.NoVersion(), aws.Int32(1), s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName == nil {
@@ -433,7 +433,7 @@ func TestGetObjectPartFields(t *testing.T) {
 	}
 
 	// after upload: SiaObject is populated and FileName remains until pinning
-	obj, err = store.GetObject(accessKeyID, bucket, name, s3.NoVersion(), aws.Int32(2))
+	obj, err = store.GetObject(aws.String(accessKeyID), bucket, name, s3.NoVersion(), aws.Int32(2), s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName == nil {
@@ -448,7 +448,7 @@ func TestGetObjectPartFields(t *testing.T) {
 	if _, err := store.MarkObjectPinned(sealed.ID()); err != nil {
 		t.Fatal(err)
 	}
-	obj, err = store.GetObject(accessKeyID, bucket, name, s3.NoVersion(), aws.Int32(2))
+	obj, err = store.GetObject(aws.String(accessKeyID), bucket, name, s3.NoVersion(), aws.Int32(2), s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName != nil {
@@ -623,7 +623,7 @@ func TestListObjects(t *testing.T) {
 
 		for _, tc := range tt.cases {
 			t.Run(tc.name, func(t *testing.T) {
-				resp, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+				resp, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 					Prefix:       tc.prefix,
 					HasPrefix:    tc.prefix != "",
 					Delimiter:    tc.delimiter,
@@ -733,7 +733,7 @@ func TestListObjectsMatch(t *testing.T) {
 		{prefix: "", delim: "/", commonPrefixes: []string{"a/", "foo/", "😊/"}},
 	} {
 		t.Run(fmt.Sprint(idx), func(t *testing.T) {
-			resp, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+			resp, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 				Prefix:       tc.prefix,
 				HasPrefix:    tc.prefix != "",
 				Delimiter:    tc.delim,
@@ -807,7 +807,7 @@ func TestListObjectsWalk(t *testing.T) {
 		stack = stack[:n]
 
 		// fetch page
-		res, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+		res, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 			Prefix:       pg.prefix,
 			HasPrefix:    pg.prefix != "",
 			Delimiter:    delimiter,
@@ -930,7 +930,7 @@ func BenchmarkListObjects(b *testing.B) {
 
 	b.Run("no_delimiter_no_prefix", func(b *testing.B) {
 		for b.Loop() {
-			result, err := store.ListObjects(testAccessKeyID, "slash", s3.Prefix{}, s3.ListObjectsPage{MaxKeys: maxKeys})
+			result, err := store.ListObjects(aws.String(testAccessKeyID), "slash", s3.Prefix{}, s3.ListObjectsPage{MaxKeys: maxKeys})
 			if err != nil {
 				b.Fatal(err)
 			} else if (len(result.Contents) + len(result.CommonPrefixes)) == 0 {
@@ -944,7 +944,7 @@ func BenchmarkListObjects(b *testing.B) {
 			for b.Loop() {
 				var marker *string
 				for {
-					result, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+					result, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 						Delimiter:    delimiter,
 						HasDelimiter: true,
 					}, s3.ListObjectsPage{MaxKeys: maxKeys, Marker: marker})
@@ -972,7 +972,7 @@ func BenchmarkListObjects(b *testing.B) {
 				case 2:
 					prefix = fmt.Sprintf("%d"+delimiter+"%d"+delimiter+"%d"+delimiter, frand.Intn(dir1), frand.Intn(dir2), frand.Intn(dir3))
 				}
-				result, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+				result, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 					Prefix:    prefix,
 					HasPrefix: true,
 				}, s3.ListObjectsPage{MaxKeys: maxKeys})
@@ -986,7 +986,7 @@ func BenchmarkListObjects(b *testing.B) {
 
 		b.Run("random_with_delimiter", func(b *testing.B) {
 			for b.Loop() {
-				result, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+				result, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 					Prefix:       fmt.Sprintf("%d"+delimiter+"%d"+delimiter, frand.Intn(dir1), frand.Intn(dir2)),
 					HasPrefix:    true,
 					Delimiter:    delimiter,
@@ -1002,7 +1002,7 @@ func BenchmarkListObjects(b *testing.B) {
 
 		b.Run("folder_bottom_delimiter", func(b *testing.B) {
 			for b.Loop() {
-				result, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+				result, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 					Prefix:       "0" + delimiter + "0" + delimiter + "0",
 					HasPrefix:    true,
 					Delimiter:    delimiter,
@@ -1018,7 +1018,7 @@ func BenchmarkListObjects(b *testing.B) {
 
 		b.Run("folder_delimiter", func(b *testing.B) {
 			for b.Loop() {
-				result, err := store.ListObjects(testAccessKeyID, bucket, s3.Prefix{
+				result, err := store.ListObjects(aws.String(testAccessKeyID), bucket, s3.Prefix{
 					Prefix:       "0" + delimiter,
 					HasPrefix:    true,
 					Delimiter:    delimiter,
@@ -1403,7 +1403,7 @@ func TestUpdateSiaObjects(t *testing.T) {
 	}
 
 	// verify the second object was updated
-	obj, err := store.GetObject(testAccessKeyID, bucket, "obj2", s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testAccessKeyID), bucket, "obj2", s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.SiaObject == nil {
@@ -1450,7 +1450,7 @@ func TestMarkObjectUploaded(t *testing.T) {
 
 	// verify the object is now on Sia but its filename is preserved on
 	// disk pending the pin
-	obj, err := store.GetObject(testAccessKeyID, bucket, object, s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testAccessKeyID), bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName == nil || *obj.FileName != fileName {
@@ -1480,7 +1480,7 @@ func TestMarkObjectUploaded(t *testing.T) {
 		t.Fatalf("expected orphan size 100, got %d", orphans[0].Size)
 	}
 
-	obj, err = store.GetObject(testAccessKeyID, bucket, object, s3.NoVersion(), nil)
+	obj, err = store.GetObject(aws.String(testAccessKeyID), bucket, object, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName != nil {
@@ -2029,7 +2029,7 @@ func TestScheduleObjectForReupload(t *testing.T) {
 	}
 
 	// the object reappears in the upload queue with sia_object_id cleared
-	obj, err := store.GetObject(accessKeyID, bucket, name, s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(accessKeyID), bucket, name, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.FileName == nil || *obj.FileName != fileName {
@@ -2158,7 +2158,7 @@ func TestVersioning(t *testing.T) {
 		}
 
 		// the current version is the latest write, and the object reports as versioned
-		if obj, err := store.GetObject(accessKeyID, bucket, key, s3.NoVersion(), nil); err != nil {
+		if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.NoVersion(), nil, s3.ActionGetObject); err != nil {
 			t.Fatal(err)
 		} else if obj.VersionID != v2 {
 			t.Fatalf("expected current version %q, got %q", v2, obj.VersionID)
@@ -2167,14 +2167,14 @@ func TestVersioning(t *testing.T) {
 		}
 
 		// each version is independently retrievable
-		if obj, err := store.GetObject(accessKeyID, bucket, key, s3.SpecificVersion(v1), nil); err != nil {
+		if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.SpecificVersion(v1), nil, s3.ActionGetObject); err != nil {
 			t.Fatal(err)
 		} else if obj.VersionID != v1 {
 			t.Fatalf("expected version %q, got %q", v1, obj.VersionID)
 		}
 
 		// an unknown version is reported as missing
-		if _, err := store.GetObject(accessKeyID, bucket, key, s3.SpecificVersion("does-not-exist"), nil); !errors.Is(err, s3errs.ErrNoSuchVersion) {
+		if _, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.SpecificVersion("does-not-exist"), nil, s3.ActionGetObject); !errors.Is(err, s3errs.ErrNoSuchVersion) {
 			t.Fatalf("expected ErrNoSuchVersion, got %v", err)
 		}
 
@@ -2187,7 +2187,7 @@ func TestVersioning(t *testing.T) {
 		} else if marker == "" {
 			t.Fatal("expected a delete marker version ID")
 		}
-		if obj, err := store.GetObject(accessKeyID, bucket, key, s3.NoVersion(), nil); err != nil {
+		if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.NoVersion(), nil, s3.ActionGetObject); err != nil {
 			t.Fatal(err)
 		} else if !obj.IsDeleteMarker {
 			t.Fatal("expected current version to be a delete marker")
@@ -2197,7 +2197,7 @@ func TestVersioning(t *testing.T) {
 		if _, _, _, err := store.DeleteObject(accessKeyID, bucket, s3.ObjectID{Key: key, VersionID: &marker}); err != nil {
 			t.Fatal(err)
 		}
-		if obj, err := store.GetObject(accessKeyID, bucket, key, s3.NoVersion(), nil); err != nil {
+		if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.NoVersion(), nil, s3.ActionGetObject); err != nil {
 			t.Fatal(err)
 		} else if obj.IsDeleteMarker {
 			t.Fatal("expected the object to be restored")
@@ -2209,10 +2209,10 @@ func TestVersioning(t *testing.T) {
 		if _, _, _, err := store.DeleteObject(accessKeyID, bucket, s3.ObjectID{Key: key, VersionID: &v1}); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := store.GetObject(accessKeyID, bucket, key, s3.SpecificVersion(v1), nil); !errors.Is(err, s3errs.ErrNoSuchVersion) {
+		if _, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.SpecificVersion(v1), nil, s3.ActionGetObject); !errors.Is(err, s3errs.ErrNoSuchVersion) {
 			t.Fatalf("expected ErrNoSuchVersion for deleted version, got %v", err)
 		}
-		if obj, err := store.GetObject(accessKeyID, bucket, key, s3.NoVersion(), nil); err != nil {
+		if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.NoVersion(), nil, s3.ActionGetObject); err != nil {
 			t.Fatal(err)
 		} else if obj.VersionID != v2 {
 			t.Fatalf("expected remaining version %q to stay current, got %q", v2, obj.VersionID)
@@ -2253,7 +2253,7 @@ func TestVersioning(t *testing.T) {
 		}
 
 		// only the null version and the original non-null version remain
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 100})
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 100})
 		if err != nil {
 			t.Fatal(err)
 		} else if len(result.Versions) != 2 {
@@ -2270,16 +2270,16 @@ func TestVersioning(t *testing.T) {
 		}
 
 		// the null version is current and addressable as the empty version ID
-		if obj, err := store.GetObject(accessKeyID, bucket, key, s3.NoVersion(), nil); err != nil {
+		if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.NoVersion(), nil, s3.ActionGetObject); err != nil {
 			t.Fatal(err)
 		} else if obj.VersionID != "" {
 			t.Fatalf("expected the null version to be current, got %q", obj.VersionID)
 		}
-		if _, err := store.GetObject(accessKeyID, bucket, key, s3.SpecificVersion(""), nil); err != nil {
+		if _, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.SpecificVersion(""), nil, s3.ActionGetObject); err != nil {
 			t.Fatalf("expected the null version to be addressable, got %v", err)
 		}
 		// the original non-null version is still retrievable
-		if obj, err := store.GetObject(accessKeyID, bucket, key, s3.SpecificVersion(v1), nil); err != nil {
+		if obj, err := store.GetObject(aws.String(accessKeyID), bucket, key, s3.SpecificVersion(v1), nil, s3.ActionGetObject); err != nil {
 			t.Fatal(err)
 		} else if obj.VersionID != v1 {
 			t.Fatalf("expected version %q, got %q", v1, obj.VersionID)
@@ -2316,7 +2316,7 @@ func TestListObjectVersions(t *testing.T) {
 	ov1 := put("other")
 
 	t.Run("Ordering", func(t *testing.T) {
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 100})
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 100})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2348,7 +2348,7 @@ func TestListObjectVersions(t *testing.T) {
 	t.Run("VersionIDMarkerResumesMidKey", func(t *testing.T) {
 		// resuming within "key" after its newest version yields the remaining two
 		// versions of "key" followed by "other"
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{
 			KeyMarker:       aws.String("key"),
 			VersionIDMarker: aws.String(s3.FormatVersion(kv3)),
 			MaxKeys:         100,
@@ -2397,7 +2397,7 @@ func TestListObjectVersions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{
 			KeyMarker:       aws.String(key),
 			VersionIDMarker: aws.String(s3.FormatVersion(kv2)),
 			MaxKeys:         100,
@@ -2441,7 +2441,7 @@ func TestListObjectVersions(t *testing.T) {
 			t.Fatalf("expected null version write to report no version, got %q", v)
 		}
 
-		first, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 1})
+		first, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 1})
 		if err != nil {
 			t.Fatal(err)
 		} else if !first.IsTruncated {
@@ -2452,7 +2452,7 @@ func TestListObjectVersions(t *testing.T) {
 			t.Fatalf("expected null next version marker, got %q", first.NextVersionIDMarker)
 		}
 
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{
 			KeyMarker:       aws.String(first.NextKeyMarker),
 			VersionIDMarker: aws.String(first.NextVersionIDMarker),
 			MaxKeys:         100,
@@ -2473,7 +2473,7 @@ func TestListObjectVersions(t *testing.T) {
 		seen := map[string]bool{}
 		page := s3.ListObjectVersionsPage{MaxKeys: 2}
 		for {
-			result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, page)
+			result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, page)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2505,7 +2505,7 @@ func TestListObjectVersions(t *testing.T) {
 	})
 
 	t.Run("MaxKeysZero", func(t *testing.T) {
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 0})
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 0})
 		if err != nil {
 			t.Fatal(err)
 		} else if len(result.Versions) != 0 {
@@ -2531,7 +2531,7 @@ func TestListObjectVersions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 100})
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 100})
 		if err != nil {
 			t.Fatal(err)
 		} else if len(result.Versions) != 2 {
@@ -2559,7 +2559,7 @@ func TestListObjectVersions(t *testing.T) {
 			}
 		}
 
-		result, err := store.ListObjectVersions(accessKeyID, bucket, s3.Prefix{
+		result, err := store.ListObjectVersions(aws.String(accessKeyID), bucket, s3.Prefix{
 			Delimiter:    "/",
 			HasDelimiter: true,
 		}, s3.ListObjectVersionsPage{MaxKeys: 100})

--- a/sia/persist/sqlite/types.go
+++ b/sia/persist/sqlite/types.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/hex"
-	"encoding/json"
+	"encoding/json/v2"
 	"fmt"
 	"strings"
 	"time"

--- a/sia/pin_test.go
+++ b/sia/pin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SiaFoundation/s3d/s3"
 	"github.com/SiaFoundation/s3d/sia/objects"
 	"github.com/SiaFoundation/s3d/sia/persist/sqlite"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"lukechampine.com/frand"
 )
 
@@ -84,7 +85,7 @@ func TestPinLoopRetriesOnFailure(t *testing.T) {
 
 	// the object is still uploaded (sia_object_id set) - failure didn't
 	// demote it, just delayed the retry
-	obj, err := store.GetObject(testutil.AccessKeyID, bucket, name, s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, name, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.SiaObject == nil {
@@ -122,7 +123,7 @@ func TestPinLoopDemotesExpiredUploads(t *testing.T) {
 	}
 
 	// the object should be back in the upload queue with sia_object_id cleared
-	obj, err := store.GetObject(testutil.AccessKeyID, bucket, name, s3.NoVersion(), nil)
+	obj, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, name, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if obj.SiaObject != nil {
@@ -185,7 +186,7 @@ func TestPinLoopPinsCopyAfterSourceDeleted(t *testing.T) {
 	}
 
 	// dst's on-disk file should have been released and its filename cleared
-	dst, err := store.GetObject(testutil.AccessKeyID, bucket, dstName, s3.NoVersion(), nil)
+	dst, err := store.GetObject(aws.String(testutil.AccessKeyID), bucket, dstName, s3.NoVersion(), nil, s3.ActionGetObject)
 	if err != nil {
 		t.Fatal(err)
 	} else if dst.SiaObject == nil {

--- a/sia/policy_test.go
+++ b/sia/policy_test.go
@@ -191,12 +191,12 @@ func TestBucketPolicyPublicReadScope(t *testing.T) {
 				},
 			},
 			{
-				name: "a missing key is still reported as missing",
+				name: "a missing key is hidden, not reported as missing",
 				do: func() error {
 					_, err := c.client.GetObjectVersion(t.Context(), bucket, "missing", nil)
 					return err
 				},
-				err: &s3errs.ErrNoSuchKey,
+				err: &s3errs.ErrAccessDenied,
 			},
 			{
 				// s3:GetObject does not cover addressing a specific version
@@ -661,4 +661,85 @@ func TestBucketPolicyCopySourceGrants(t *testing.T) {
 	if _, err := other.CopyObjectVersion(t.Context(), public, object, aws.String(oldVersion), own, "copy-old"); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestBucketPolicyMissingKeyVisibility checks that a missing key is reported as
+// missing only to a caller allowed to list the bucket. Without s3:ListBucket,
+// S3 returns AccessDenied so the caller cannot probe for keys.
+func TestBucketPolicyMissingKeyVisibility(t *testing.T) {
+	const bucket = "bucket"
+
+	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	// the owner may always list, so it still sees a plain 404
+	_, err := s3Tester.GetObjectVersion(t.Context(), bucket, "missing", nil)
+	testutil.AssertS3Error(t, s3errs.ErrNoSuchKey, err)
+
+	// read but no list: existence is hidden
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, publicReadPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		_, err := c.client.GetObjectVersion(t.Context(), bucket, "missing", nil)
+		testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+	})
+
+	// read and list: the key is reported missing
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, readAndListPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		_, err := c.client.GetObjectVersion(t.Context(), bucket, "missing", nil)
+		testutil.AssertS3Error(t, s3errs.ErrNoSuchKey, err)
+	})
+}
+
+// TestBucketPolicyDeleteMarkerHidden checks that a delete-marked key is
+// indistinguishable from one that never existed for a caller that may not list
+// the bucket. Otherwise the 404 and its delete-marker headers reveal that the
+// key was once there.
+func TestBucketPolicyDeleteMarkerHidden(t *testing.T) {
+	const (
+		bucket = "bucket"
+		object = "key"
+	)
+
+	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if err := s3Tester.PutBucketVersioning(t.Context(), bucket, types.BucketVersioningStatusEnabled); err != nil {
+		t.Fatal(err)
+	} else if _, err := s3Tester.PutObjectVersion(t.Context(), bucket, object, []byte("value")); err != nil {
+		t.Fatal(err)
+	} else if err := s3Tester.DeleteObject(t.Context(), bucket, object); err != nil {
+		t.Fatal(err)
+	}
+
+	// read but no list: the delete marker looks exactly like an absent key
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, publicReadPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		_, err := c.client.GetObjectVersion(t.Context(), bucket, object, nil)
+		testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+		_, err = c.client.GetObjectVersion(t.Context(), bucket, "never-existed", nil)
+		testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+		// nor can a copy be used to tell them apart
+		_, err = c.client.CopyObjectVersion(t.Context(), bucket, object, nil, bucket, "copy")
+		testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+	})
+
+	// with s3:ListBucket the delete marker is reported as such
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, readAndListPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		_, err := c.client.GetObjectVersion(t.Context(), bucket, object, nil)
+		testutil.AssertS3StatusCode(t, s3errs.ErrNoSuchKey, err)
+	})
 }

--- a/sia/policy_test.go
+++ b/sia/policy_test.go
@@ -588,6 +588,14 @@ func TestBucketPolicyListingReportsBucketOwner(t *testing.T) {
 	}
 
 	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		v1, err := c.client.ListObjects(t.Context(), bucket, nil, nil, s3.ListObjectsPage{})
+		if err != nil {
+			t.Fatal(err)
+		} else if len(v1.Contents) != 1 {
+			t.Fatalf("unexpected v1 listing: %v", v1.Contents)
+		}
+		assertOwner(t, v1.Contents[0].Owner)
+
 		listed, err := c.client.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{FetchOwner: aws.Bool(true)})
 		if err != nil {
 			t.Fatal(err)

--- a/sia/policy_test.go
+++ b/sia/policy_test.go
@@ -1,0 +1,664 @@
+package sia_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/SiaFoundation/s3d/internal/testutil"
+	"github.com/SiaFoundation/s3d/s3"
+	"github.com/SiaFoundation/s3d/s3/s3errs"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// A "*" principal covers unsigned requests and signed requests from non-owners.
+// The two take different paths through the backend, so both are asserted.
+const (
+	otherAccessKeyID = "foo"
+	otherSecretKey   = "bar"
+)
+
+// publicCaller is one kind of caller a "*" principal covers.
+type publicCaller struct {
+	client *testutil.S3Tester
+	// missingBucket is what this caller sees for a bucket that does not exist;
+	// an anonymous one must not learn that.
+	missingBucket *s3errs.Error
+}
+
+// forEachPublicCaller runs fn for both kinds of caller. The tester must have
+// been created with the "other" key pair registered.
+func forEachPublicCaller(t *testing.T, s3Tester *testutil.S3Tester, fn func(*testing.T, publicCaller)) {
+	t.Helper()
+	for _, c := range []struct {
+		name   string
+		caller publicCaller
+	}{
+		{"anonymous", publicCaller{s3Tester.Anonymous(), &s3errs.ErrAccessDenied}},
+		{"other user", publicCaller{s3Tester.ChangeAccessKey(t, otherAccessKeyID, otherSecretKey), &s3errs.ErrNoSuchBucket}},
+	} {
+		t.Run(c.name, func(t *testing.T) { fn(t, c.caller) })
+	}
+}
+
+// publicReadPolicy makes every object in the bucket readable by anyone.
+func publicReadPolicy(bucket string) string {
+	return fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicRead",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::%s/*"
+    }
+  ]
+}`, bucket)
+}
+
+// readAndListPolicy grants every action s3d can hand to anonymous callers.
+func readAndListPolicy(bucket string) string {
+	return fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:GetObject", "s3:GetObjectVersion"],
+      "Resource": "arn:aws:s3:::%s/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:ListBucket", "s3:ListBucketVersions"],
+      "Resource": "arn:aws:s3:::%s"
+    }
+  ]
+}`, bucket, bucket)
+}
+
+func TestBucketPolicyPublicRead(t *testing.T) {
+	const (
+		bucket = "bucket"
+		object = "key"
+	)
+	contents := []byte("value")
+
+	s3Tester := testutil.NewTester(t)
+	anon := s3Tester.Anonymous()
+
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if _, err := s3Tester.PutObject(t.Context(), bucket, object, bytes.NewReader(contents), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// a bucket with no policy has none to get
+	_, err := s3Tester.GetBucketPolicy(t.Context(), bucket)
+	testutil.AssertS3Error(t, s3errs.ErrNoSuchBucketPolicy, err)
+
+	// and is not public
+	if public, err := s3Tester.GetBucketPolicyStatus(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if public {
+		t.Fatal("expected bucket without a policy to not be public")
+	}
+
+	// so an anonymous read is denied
+	_, err = anon.GetObjectVersion(t.Context(), bucket, object, nil)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	// make the bucket public
+	policy := publicReadPolicy(bucket)
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, policy); err != nil {
+		t.Fatal(err)
+	}
+
+	// the document must round-trip byte-for-byte
+	if got, err := s3Tester.GetBucketPolicy(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if got != policy {
+		t.Fatalf("expected policy %q, got %q", policy, got)
+	}
+
+	if public, err := s3Tester.GetBucketPolicyStatus(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if !public {
+		t.Fatal("expected bucket to be public")
+	}
+
+	// the anonymous read now succeeds
+	if body, err := anon.GetObjectVersion(t.Context(), bucket, object, nil); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(body, contents) {
+		t.Fatalf("expected %q, got %q", contents, body)
+	}
+
+	// removing the policy revokes the access again
+	if err := s3Tester.DeleteBucketPolicy(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s3Tester.GetBucketPolicy(t.Context(), bucket)
+	testutil.AssertS3Error(t, s3errs.ErrNoSuchBucketPolicy, err)
+
+	_, err = anon.GetObjectVersion(t.Context(), bucket, object, nil)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+}
+
+// TestBucketPolicyPublicReadScope checks that a public-read policy opens up
+// exactly what it describes and nothing more.
+func TestBucketPolicyPublicReadScope(t *testing.T) {
+	const (
+		bucket  = "bucket"
+		private = "private-bucket"
+		object  = "key"
+	)
+
+	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+
+	for _, b := range []string{bucket, private} {
+		if err := s3Tester.CreateBucket(t.Context(), b); err != nil {
+			t.Fatal(err)
+		} else if _, err := s3Tester.PutObject(t.Context(), b, object, bytes.NewReader([]byte("value")), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, publicReadPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+
+	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		tests := []struct {
+			name string
+			do   func() error
+			err  *s3errs.Error
+		}{
+			{
+				name: "read the public object",
+				do: func() error {
+					_, err := c.client.GetObjectVersion(t.Context(), bucket, object, nil)
+					return err
+				},
+			},
+			{
+				name: "head the public object",
+				do: func() error {
+					_, err := c.client.HeadObject(t.Context(), bucket, object, nil)
+					return err
+				},
+			},
+			{
+				name: "a missing key is still reported as missing",
+				do: func() error {
+					_, err := c.client.GetObjectVersion(t.Context(), bucket, "missing", nil)
+					return err
+				},
+				err: &s3errs.ErrNoSuchKey,
+			},
+			{
+				// s3:GetObject does not cover addressing a specific version
+				name: "read a specific version",
+				do: func() error {
+					_, err := c.client.GetObjectVersion(t.Context(), bucket, object, aws.String("null"))
+					return err
+				},
+				err: &s3errs.ErrAccessDenied,
+			},
+			{
+				// the policy grants no s3:ListBucket
+				name: "list the bucket",
+				do: func() error {
+					_, err := c.client.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{})
+					return err
+				},
+				err: &s3errs.ErrAccessDenied,
+			},
+			{
+				// nor s3:ListBucketVersions
+				name: "list the bucket's versions",
+				do: func() error {
+					_, err := c.client.ListObjectVersionsPage(t.Context(), bucket, nil)
+					return err
+				},
+				err: &s3errs.ErrAccessDenied,
+			},
+			{
+				name: "write an object",
+				do: func() error {
+					_, err := c.client.PutObject(t.Context(), bucket, "other", bytes.NewReader([]byte("nope")), nil)
+					return err
+				},
+				err: &s3errs.ErrAccessDenied,
+			},
+			{
+				name: "delete the object",
+				do:   func() error { return c.client.DeleteObject(t.Context(), bucket, object) },
+				err:  &s3errs.ErrAccessDenied,
+			},
+			{
+				name: "read the policy",
+				do: func() error {
+					_, err := c.client.GetBucketPolicy(t.Context(), bucket)
+					return err
+				},
+				err: &s3errs.ErrAccessDenied,
+			},
+			{
+				name: "the policy covers only its own bucket",
+				do: func() error {
+					_, err := c.client.GetObjectVersion(t.Context(), private, object, nil)
+					return err
+				},
+				err: &s3errs.ErrAccessDenied,
+			},
+			{
+				// an anonymous caller must not learn whether a bucket it may not
+				// touch exists; a signed one already gets NoSuchBucket from the
+				// ordinary ownership check
+				name: "a bucket that does not exist",
+				do: func() error {
+					_, err := c.client.GetObjectVersion(t.Context(), "nonexistent", object, nil)
+					return err
+				},
+				err: c.missingBucket,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				err := test.do()
+				if test.err == nil {
+					if err != nil {
+						t.Fatalf("expected success, got %v", err)
+					}
+					return
+				}
+				testutil.AssertS3Error(t, *test.err, err)
+			})
+		}
+	})
+}
+
+// TestBucketPolicyOwnership checks that only the owner can read or change the
+// policy.
+func TestBucketPolicyOwnership(t *testing.T) {
+	const bucket = "bucket"
+
+	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+	other := s3Tester.ChangeAccessKey(t, otherAccessKeyID, otherSecretKey)
+
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := publicReadPolicy(bucket)
+	err := other.PutBucketPolicy(t.Context(), bucket, policy)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, policy); err != nil {
+		t.Fatal(err)
+	}
+
+	// a publicly readable bucket does not have a publicly readable configuration
+	_, err = other.GetBucketPolicy(t.Context(), bucket)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	err = other.DeleteBucketPolicy(t.Context(), bucket)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	// the owner's policy survived
+	if got, err := s3Tester.GetBucketPolicy(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if got != policy {
+		t.Fatalf("expected policy %q, got %q", policy, got)
+	}
+
+	// nor does a public bucket show up in anyone else's bucket list
+	if buckets, err := other.ListBuckets(t.Context()); err != nil {
+		t.Fatal(err)
+	} else if len(buckets) != 0 {
+		t.Fatalf("expected no buckets for the other user, got %v", buckets)
+	}
+}
+
+// TestBucketPolicyRejected checks that a policy s3d cannot honor is refused
+// rather than stored as a weaker one.
+func TestBucketPolicyRejected(t *testing.T) {
+	const bucket = "bucket"
+
+	s3Tester := testutil.NewTester(t)
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		policy string
+		err    s3errs.Error
+	}{
+		{
+			name:   "malformed",
+			policy: `not a policy`,
+			err:    s3errs.ErrMalformedPolicy,
+		},
+		{
+			name: "conditional grant",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+				"Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/*",
+				"Condition":{"IpAddress":{"aws:SourceIp":"10.0.0.0/8"}}}]}`,
+			err: s3errs.ErrNotImplemented,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := s3Tester.PutBucketPolicy(t.Context(), bucket, test.policy)
+			testutil.AssertS3Error(t, test.err, err)
+
+			// a rejected policy must leave no trace
+			_, err = s3Tester.GetBucketPolicy(t.Context(), bucket)
+			testutil.AssertS3Error(t, s3errs.ErrNoSuchBucketPolicy, err)
+		})
+	}
+}
+
+// TestBucketPolicyPublicListAndVersions checks the list and version grants.
+func TestBucketPolicyPublicListAndVersions(t *testing.T) {
+	const (
+		bucket = "bucket"
+		object = "key"
+	)
+
+	s3Tester := testutil.NewTester(t)
+	anon := s3Tester.Anonymous()
+
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if err := s3Tester.PutBucketVersioning(t.Context(), bucket, types.BucketVersioningStatusEnabled); err != nil {
+		t.Fatal(err)
+	}
+
+	// two versions, so a versioned read has an older one to address
+	oldVersion, err := s3Tester.PutObjectVersion(t.Context(), bucket, object, []byte("old"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s3Tester.PutObjectVersion(t.Context(), bucket, object, []byte("new")); err != nil {
+		t.Fatal(err)
+	}
+
+	// none of it is reachable before the policy exists
+	_, err = anon.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{})
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, readAndListPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+
+	// ListObjects v1 and v2
+	v1, err := anon.ListObjects(t.Context(), bucket, nil, nil, s3.ListObjectsPage{})
+	if err != nil {
+		t.Fatal(err)
+	} else if len(v1.Contents) != 1 || aws.ToString(v1.Contents[0].Key) != object {
+		t.Fatalf("unexpected v1 listing: %v", v1.Contents)
+	}
+
+	v2, err := anon.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{})
+	if err != nil {
+		t.Fatal(err)
+	} else if len(v2.Contents) != 1 || aws.ToString(v2.Contents[0].Key) != object {
+		t.Fatalf("unexpected v2 listing: %v", v2.Contents)
+	}
+
+	// ListObjectVersions
+	versions, err := anon.ListObjectVersionsPage(t.Context(), bucket, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(versions.Versions) != 2 {
+		t.Fatalf("expected 2 versions, got %d", len(versions.Versions))
+	}
+
+	// the current version, and an older one by ID
+	if body, err := anon.GetObjectVersion(t.Context(), bucket, object, nil); err != nil {
+		t.Fatal(err)
+	} else if string(body) != "new" {
+		t.Fatalf("expected %q, got %q", "new", body)
+	}
+	if body, err := anon.GetObjectVersion(t.Context(), bucket, object, aws.String(oldVersion)); err != nil {
+		t.Fatal(err)
+	} else if string(body) != "old" {
+		t.Fatalf("expected %q, got %q", "old", body)
+	}
+
+	// writes are still denied
+	_, err = anon.PutObject(t.Context(), bucket, "other", bytes.NewReader([]byte("nope")), nil)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+}
+
+// TestBucketPolicyGrantsAreIndependent checks that allowing listing does not
+// also allow reading, or vice versa.
+func TestBucketPolicyGrantsAreIndependent(t *testing.T) {
+	const (
+		bucket = "bucket"
+		object = "key"
+	)
+
+	// each policy grants exactly one action; every other action must stay denied
+	grants := []struct{ action, resource string }{
+		{"s3:GetObject", bucket + "/*"},
+		{"s3:GetObjectVersion", bucket + "/*"},
+		{"s3:ListBucket", bucket},
+		{"s3:ListBucketVersions", bucket},
+	}
+
+	for _, grant := range grants {
+		t.Run(grant.action, func(t *testing.T) {
+			s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+			if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+				t.Fatal(err)
+			} else if err := s3Tester.PutBucketVersioning(t.Context(), bucket, types.BucketVersioningStatusEnabled); err != nil {
+				t.Fatal(err)
+			}
+			version, err := s3Tester.PutObjectVersion(t.Context(), bucket, object, []byte("value"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := s3Tester.PutBucketPolicy(t.Context(), bucket, statementPolicy(grant.action, grant.resource)); err != nil {
+				t.Fatal(err)
+			}
+
+			forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+				// what each action does when the policy allows it
+				attempts := []struct {
+					action string
+					do     func() error
+				}{
+					{"s3:GetObject", func() error {
+						_, err := c.client.GetObjectVersion(t.Context(), bucket, object, nil)
+						return err
+					}},
+					{"s3:GetObjectVersion", func() error {
+						_, err := c.client.GetObjectVersion(t.Context(), bucket, object, aws.String(version))
+						return err
+					}},
+					{"s3:ListBucket", func() error {
+						_, err := c.client.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{})
+						return err
+					}},
+					{"s3:ListBucketVersions", func() error {
+						_, err := c.client.ListObjectVersionsPage(t.Context(), bucket, nil)
+						return err
+					}},
+				}
+
+				for _, attempt := range attempts {
+					t.Run(attempt.action, func(t *testing.T) {
+						err := attempt.do()
+						if attempt.action == grant.action {
+							if err != nil {
+								t.Fatalf("expected the granted action to succeed, got %v", err)
+							}
+							return
+						}
+						testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+					})
+				}
+			})
+		})
+	}
+}
+
+// statementPolicy grants action on resource to everyone.
+func statementPolicy(action, resource string) string {
+	return fmt.Sprintf(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",
+		"Action":"%s","Resource":"arn:aws:s3:::%s"}]}`, action, resource)
+}
+
+// TestBucketPolicyListAuthorizesEmptyPage checks that a listing requesting no
+// keys is still authorized. It drives the backend directly because the AWS
+// client omits MaxKeys when it is zero.
+func TestBucketPolicyListAuthorizesEmptyPage(t *testing.T) {
+	const (
+		bucket = "bucket"
+		object = "key"
+	)
+
+	backend, _ := testutil.NewBackend(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+	if err := backend.CreateBucket(t.Context(), testutil.AccessKeyID, bucket); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.PutObject(t.Context(), testutil.AccessKeyID, bucket, object,
+		bytes.NewReader([]byte("value")), s3.PutObjectOptions{ContentLength: 5}); err != nil {
+		t.Fatal(err)
+	}
+
+	// the bucket has no policy at all, so neither caller may list it
+	otherKey := otherAccessKeyID
+	for _, caller := range []struct {
+		name        string
+		accessKeyID *string
+	}{
+		{"anonymous", nil},
+		{"other user", &otherKey},
+	} {
+		t.Run(caller.name, func(t *testing.T) {
+			_, err := backend.ListObjects(t.Context(), caller.accessKeyID, bucket, s3.Prefix{}, s3.ListObjectsPage{MaxKeys: 0})
+			if !errors.Is(err, s3errs.ErrAccessDenied) {
+				t.Fatalf("ListObjects: expected %v, got %v", s3errs.ErrAccessDenied, err)
+			}
+
+			_, err = backend.ListObjectVersions(t.Context(), caller.accessKeyID, bucket, s3.Prefix{}, s3.ListObjectVersionsPage{MaxKeys: 0})
+			if !errors.Is(err, s3errs.ErrAccessDenied) {
+				t.Fatalf("ListObjectVersions: expected %v, got %v", s3errs.ErrAccessDenied, err)
+			}
+		})
+	}
+}
+
+// TestBucketPolicyListingReportsBucketOwner checks that a listing attributes
+// objects to the bucket's owner rather than to whoever asked for the listing.
+func TestBucketPolicyListingReportsBucketOwner(t *testing.T) {
+	const (
+		bucket = "bucket"
+		object = "key"
+	)
+
+	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if err := s3Tester.PutBucketVersioning(t.Context(), bucket, types.BucketVersioningStatusEnabled); err != nil {
+		t.Fatal(err)
+	} else if _, err := s3Tester.PutObject(t.Context(), bucket, object, bytes.NewReader([]byte("value")), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s3Tester.PutBucketPolicy(t.Context(), bucket, readAndListPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+
+	assertOwner := func(t *testing.T, owner *types.Owner) {
+		t.Helper()
+		if owner == nil {
+			t.Fatal("expected an owner")
+		} else if aws.ToString(owner.ID) != testutil.Owner {
+			t.Fatalf("expected owner %q, got %q", testutil.Owner, aws.ToString(owner.ID))
+		}
+	}
+
+	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		listed, err := c.client.ListObjectsV2(t.Context(), bucket, nil, nil, s3.ListObjectsPage{FetchOwner: aws.Bool(true)})
+		if err != nil {
+			t.Fatal(err)
+		} else if len(listed.Contents) != 1 {
+			t.Fatalf("unexpected listing: %v", listed.Contents)
+		}
+		assertOwner(t, listed.Contents[0].Owner)
+
+		// the versions endpoint always asks for owner data
+		versions, err := c.client.ListObjectVersionsPage(t.Context(), bucket, nil)
+		if err != nil {
+			t.Fatal(err)
+		} else if len(versions.Versions) != 1 {
+			t.Fatalf("expected 1 version, got %d", len(versions.Versions))
+		}
+		assertOwner(t, versions.Versions[0].Owner)
+	})
+}
+
+// TestBucketPolicyCopySourceGrants checks that the copy paths authorize their
+// source read per version, as a direct read does.
+func TestBucketPolicyCopySourceGrants(t *testing.T) {
+	const (
+		public = "public-bucket"
+		own    = "own-bucket"
+		object = "key"
+	)
+
+	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+	other := s3Tester.ChangeAccessKey(t, otherAccessKeyID, otherSecretKey)
+
+	if err := s3Tester.CreateBucket(t.Context(), public); err != nil {
+		t.Fatal(err)
+	} else if err := s3Tester.PutBucketVersioning(t.Context(), public, types.BucketVersioningStatusEnabled); err != nil {
+		t.Fatal(err)
+	}
+	oldVersion, err := s3Tester.PutObjectVersion(t.Context(), public, object, []byte("old"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s3Tester.PutObjectVersion(t.Context(), public, object, []byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := other.CreateBucket(t.Context(), own); err != nil {
+		t.Fatal(err)
+	}
+
+	// s3:GetObject only: the current version may be copied, an older one may not
+	if err := s3Tester.PutBucketPolicy(t.Context(), public, publicReadPolicy(public)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := other.CopyObjectVersion(t.Context(), public, object, nil, own, "copy"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = other.CopyObjectVersion(t.Context(), public, object, aws.String(oldVersion), own, "copy-old")
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	// UploadPartCopy authorizes its source the same way
+	upload, err := other.CreateMultipartUpload(t.Context(), own, "multipart", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = other.UploadPartCopy(t.Context(), public, object, own, "multipart", aws.ToString(upload.UploadId),
+		testutil.UploadPartCopyOptions{PartNumber: 1, SourceVersionID: aws.String(oldVersion)})
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	// granting the version action unlocks both
+	if err := s3Tester.PutBucketPolicy(t.Context(), public, readAndListPolicy(public)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := other.CopyObjectVersion(t.Context(), public, object, aws.String(oldVersion), own, "copy-old"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -185,16 +185,19 @@ type Store interface {
 	CreateBucket(accessKeyID, bucket string) error
 	DeleteBucket(accessKeyID, bucket string) error
 	DeleteObject(accessKeyID, bucket string, objectID s3.ObjectID) (string, bool, objects.OrphanedFile, error)
-	GetObject(accessKeyID, bucket, object string, version s3.VersionRequest, partNumber *int32) (*objects.Object, error)
+	GetObject(accessKeyID *string, bucket, object string, version s3.VersionRequest, partNumber *int32, action s3.PolicyActions) (*objects.Object, error)
 	DiskUsage() (uint64, error)
 	HeadBucket(accessKeyID, bucket string) error
 	GetBucketVersioning(accessKeyID, bucket string) (string, error)
 	PutBucketVersioning(accessKeyID, bucket, status string) error
+	GetBucketPolicy(accessKeyID, bucket string) (s3.BucketPolicy, error)
+	PutBucketPolicy(accessKeyID, bucket string, policy s3.BucketPolicy) error
+	DeleteBucketPolicy(accessKeyID, bucket string) error
 	ObjectsCursor() (slabs.Cursor, error)
 	SetObjectsCursor(cursor slabs.Cursor) error
 	ListBuckets(accessKeyID string) ([]s3.BucketInfo, error)
-	ListObjects(accessKeyID, bucket string, prefix s3.Prefix, page s3.ListObjectsPage) (*s3.ObjectsListResult, error)
-	ListObjectVersions(accessKeyID, bucket string, prefix s3.Prefix, page s3.ListObjectVersionsPage) (*s3.ObjectVersionsListResult, error)
+	ListObjects(accessKeyID *string, bucket string, prefix s3.Prefix, page s3.ListObjectsPage) (*s3.ObjectsListResult, error)
+	ListObjectVersions(accessKeyID *string, bucket string, prefix s3.Prefix, page s3.ListObjectVersionsPage) (*s3.ObjectVersionsListResult, error)
 	ObjectPartsByName(bucket, name, versionID string) ([]objects.Part, error)
 	ObjectsForUpload() ([]objects.ObjectForUpload, error)
 	OrphanedObjects(limit int) ([]types.Hash256, error)

--- a/tox/tox_test.go
+++ b/tox/tox_test.go
@@ -156,7 +156,7 @@ func TestS3(t *testing.T) {
 	t.Run("test_s3", func(t *testing.T) {
 		runTox(t, confPath, testsDir,
 			"s3tests/functional/test_s3.py",
-			"-m", "not s3d_not_implemented and not s3d_not_supported and not bucket_logging and not encryption and not sse_s3 and not bucket_encryption and not lifecycle_transition and not tagging and not bucket_policy and not object_ownership and not checksum and not cloud_transition and not cloud_restore and not iam_user and not iam_account",
+			"-m", "not s3d_not_implemented and not s3d_not_supported and not bucket_logging and not encryption and not sse_s3 and not bucket_encryption and not lifecycle_transition and not tagging and not object_ownership and not checksum and not cloud_transition and not cloud_restore and not iam_user and not iam_account",
 			// the lifecycle exclusions drop tests for unimplemented features:
 			// tag and object-size filters, noncurrent-version and delete-marker
 			// actions, and transitions. lifecycle_expiration_versioned is one of


### PR DESCRIPTION
Tried to move our releases over from renterd to s3d and noticed we don't have public buckets yet. This PR adds that via bucket policies. 

It won't allow arbitrary policies and instead only ones for `GetObject`, `ListBucket` and their versioned counterparts where the target is everyone (the `*` principal) 