### PR TITLE
Return s3 error when routing fails

### DIFF
--- a/.changeset/answer_service_root_requests_with_an_s3_error_instead_of_a_plain_404.md
+++ b/.changeset/answer_service_root_requests_with_an_s3_error_instead_of_a_plain_404.md
@@ -1,0 +1,10 @@
+---
+default: patch
+---
+
+# Answer service root requests with an S3 error instead of a plain 404
+
+Non-GET requests to the service root returned Go's plain-text `404 page not
+found`. AWS dispatches on the method before authenticating there, answering 405
+with an `Allow: GET` header, and clients that probe the root before logging in,
+such as Cyberduck sending an unsigned `HEAD /`, cannot connect otherwise.

--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -200,16 +200,17 @@ func handleAuthV4a(_ *http.Request) (*string, error) {
 	return nil, s3errs.ErrNotImplemented // Signature Version 4A is not implemented
 }
 
-// AccessKeyIDFromRequest returns the access key ID from the request's
-// Authorization header. It only parses, never verifies, so the result is
-// suitable for logging a failed authentication and nothing else. It returns an
-// empty string if the header is absent or malformed.
+// AccessKeyIDFromRequest returns the access key ID a request presented, from the
+// Authorization header or a presigned URL's credential parameter. It parses but
+// never verifies, so use it only to log a failed authentication.
 func AccessKeyIDFromRequest(req *http.Request) string {
-	header, err := parseAuthHeader(req.Header)
-	if err != nil {
-		return ""
+	if header, err := parseAuthHeader(req.Header); err == nil {
+		return header.Credential.AccessKeyID
 	}
-	return header.Credential.AccessKeyID
+	if credential, ok := parseCredential(req.URL.Query().Get(QueryXAMZCredential)); ok {
+		return credential.AccessKeyID
+	}
+	return ""
 }
 
 // Sha256HashFromRequest extracts the SHA256 hash of the payload from the

--- a/s3/auth/auth.go
+++ b/s3/auth/auth.go
@@ -200,6 +200,18 @@ func handleAuthV4a(_ *http.Request) (*string, error) {
 	return nil, s3errs.ErrNotImplemented // Signature Version 4A is not implemented
 }
 
+// AccessKeyIDFromRequest returns the access key ID from the request's
+// Authorization header. It only parses, never verifies, so the result is
+// suitable for logging a failed authentication and nothing else. It returns an
+// empty string if the header is absent or malformed.
+func AccessKeyIDFromRequest(req *http.Request) string {
+	header, err := parseAuthHeader(req.Header)
+	if err != nil {
+		return ""
+	}
+	return header.Credential.AccessKeyID
+}
+
 // Sha256HashFromRequest extracts the SHA256 hash of the payload from the
 // request if available. This hash should then be used to verify the integrity
 // of the payload.

--- a/s3/response.go
+++ b/s3/response.go
@@ -62,6 +62,10 @@ func writeErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	if w.Header().Get("x-amz-delete-marker") != "" {
 		keep = []string{"X-Amz-Delete-Marker", "X-Amz-Version-Id", "Last-Modified", "Allow"}
 	}
+	if s3Err.HTTPStatus == http.StatusMethodNotAllowed {
+		// a 405 has to say which methods are accepted
+		keep = append(keep, "Allow")
+	}
 
 	// clear any headers that may have been set before the error was detected
 	// (e.g. conditional GET sets ETag and metadata before checking If-Match)

--- a/s3/root_test.go
+++ b/s3/root_test.go
@@ -1,0 +1,47 @@
+package s3_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SiaFoundation/s3d/internal/testutil"
+	"github.com/SiaFoundation/s3d/s3"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestServiceRootMethods tests that requests to the service root which are not
+// ListBuckets are answered the way AWS answers them: 405 with "Allow: GET",
+// dispatched on the method before authentication. Clients probe the root before
+// logging in -- Cyberduck sends an unsigned HEAD / -- and treat anything else,
+// including a 403, as a failed connection.
+func TestServiceRootMethods(t *testing.T) {
+	backend, _ := testutil.NewBackend(t)
+	handler := s3.New(backend, s3.WithLogger(zaptest.NewLogger(t)))
+
+	for _, method := range []string{http.MethodHead, http.MethodPut, http.MethodPost, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "http://localhost/", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+			}
+			if got := rec.Header().Get("Allow"); got != http.MethodGet {
+				t.Errorf("Allow = %q, want %q", got, http.MethodGet)
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "xml") {
+				t.Errorf("Content-Type = %q, want an XML type", ct)
+			}
+			// HEAD responses carry no body
+			if method != http.MethodHead {
+				if body := rec.Body.String(); !strings.Contains(body, "MethodNotAllowed") {
+					t.Errorf("body = %q, want it to contain MethodNotAllowed", body)
+				}
+			}
+		})
+	}
+}

--- a/s3/root_test.go
+++ b/s3/root_test.go
@@ -11,11 +11,10 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-// TestServiceRootMethods tests that requests to the service root which are not
-// ListBuckets are answered the way AWS answers them: 405 with "Allow: GET",
-// dispatched on the method before authentication. Clients probe the root before
-// logging in -- Cyberduck sends an unsigned HEAD / -- and treat anything else,
-// including a 403, as a failed connection.
+// TestServiceRootMethods tests that an unsigned request to the service root
+// that is not ListBuckets gets 405 with "Allow: GET", as AWS does. Clients
+// probe the root before logging in -- Cyberduck sends an unsigned HEAD / -- and
+// treat anything else, including a 403, as a failed connection.
 func TestServiceRootMethods(t *testing.T) {
 	backend, _ := testutil.NewBackend(t)
 	handler := s3.New(backend, s3.WithLogger(zaptest.NewLogger(t)))
@@ -41,6 +40,30 @@ func TestServiceRootMethods(t *testing.T) {
 				if body := rec.Body.String(); !strings.Contains(body, "MethodNotAllowed") {
 					t.Errorf("body = %q, want it to contain MethodNotAllowed", body)
 				}
+			}
+		})
+	}
+}
+
+// TestServiceRootAuthenticatesFirst checks that only an unsigned root request
+// gets the 405 above: a request that presents credentials is authenticated
+// first, so a bad signature fails as such rather than being answered by method.
+func TestServiceRootAuthenticatesFirst(t *testing.T) {
+	backend, _ := testutil.NewBackend(t)
+	handler := s3.New(backend, s3.WithLogger(zaptest.NewLogger(t)))
+
+	for _, header := range []string{"AWS4-HMAC-SHA256 garbage", "Bogus xyz"} {
+		t.Run(header, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodHead, "http://localhost/", nil)
+			req.Header.Set("Authorization", header)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusMethodNotAllowed {
+				t.Fatal("expected authentication to reject the request, got 405")
+			} else if rec.Code < 400 || rec.Code > 499 {
+				t.Fatalf("expected a client error, got %d", rec.Code)
 			}
 		})
 	}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -643,8 +643,8 @@ func (s *s3) routeBase(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 	} else if r.Method == "GET" {
 		err = s.listBuckets(w, r, accessKeyID)
 	} else {
-		// AWS dispatches on the method before authenticating the service root,
-		// answering 405 with "Allow: GET" even to an unsigned request
+		// an unsigned request arrives here as anonymous, and clients probing the
+		// root expect 405 with "Allow: GET" rather than a 403
 		w.Header().Set("Allow", http.MethodGet)
 		err = s3errs.ErrMethodNotAllowed
 	}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -532,7 +532,8 @@ func (s s3) authMiddleware(handler auth.AuthenticatedHandler) http.Handler {
 		// NOTE: If 'region' is empty here, all regions are allowed.
 		accessKeyID, err := auth.HandleAuth(req, s.backend, s.region, time.Now())
 		if err != nil {
-			s.logger.Debug("authentication failed", zap.Error(err))
+			s.logger.Debug("authentication failed", zap.Error(err),
+				zap.String("accessKeyID", auth.AccessKeyIDFromRequest(req)))
 			writeErrorResponse(w, req, err)
 			return
 		}
@@ -642,8 +643,10 @@ func (s *s3) routeBase(w http.ResponseWriter, r *http.Request, accessKeyID *stri
 	} else if r.Method == "GET" {
 		err = s.listBuckets(w, r, accessKeyID)
 	} else {
-		http.NotFound(w, r)
-		return
+		// AWS dispatches on the method before authenticating the service root,
+		// answering 405 with "Allow: GET" even to an unsigned request
+		w.Header().Set("Allow", http.MethodGet)
+		err = s3errs.ErrMethodNotAllowed
 	}
 	if err != nil {
 		// only consider 5xx errors as "real" errors when logging. Other errors


### PR DESCRIPTION
This fixes an issue I encountered while testing Cyberduck where connecting failed due to an initial probe not receiving the response it expected.