### PR TITLE
Authorize HeadBucket with ListBucket policy

### DIFF
--- a/.changeset/authorize_headbucket_with_s3_listbucket.md
+++ b/.changeset/authorize_headbucket_with_s3_listbucket.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Authorize HeadBucket with s3:ListBucket

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ actions are drawn from this set:
 |--------|----------|--------|
 | `s3:GetObject` | `arn:aws:s3:::<bucket>/*` | `GetObject`, `HeadObject` |
 | `s3:GetObjectVersion` | `arn:aws:s3:::<bucket>/*` | `GetObject`, `HeadObject` for a specific `versionId` |
-| `s3:ListBucket` | `arn:aws:s3:::<bucket>` | `ListObjects` v1 and v2 |
+| `s3:ListBucket` | `arn:aws:s3:::<bucket>` | `ListObjects` v1 and v2, `HeadBucket` |
 | `s3:ListBucketVersions` | `arn:aws:s3:::<bucket>` | `ListObjectVersions` |
 
 Each action is granted on its own, so a policy that allows listing does not also
@@ -246,11 +246,10 @@ S3. A policy granting everything looks like this:
 
 A `*` principal covers every caller, so the grant applies to signed requests
 from other users as well as to unsigned ones. Nothing beyond those four actions
-follows from it: writes, deletes, `HeadBucket` and the bucket's own
-configuration all still require the owner's credentials, only the owner can
-read, change or remove the policy, and the bucket does not appear in anyone
-else's `ListBuckets`. A listing reports the bucket's owner, which is not
-necessarily the caller.
+follows from it: writes, deletes, and the bucket's own configuration all still
+require the owner's credentials, only the owner can read, change or remove the
+policy, and the bucket does not appear in anyone else's `ListBuckets`. A
+listing reports the bucket's owner, which is not necessarily the caller.
 
 Any policy s3d cannot honor exactly is rejected rather than partially applied,
 so an accepted policy never grants more access than it describes: `Deny`
@@ -280,7 +279,7 @@ delete with nothing to delete is a no-op, as an unconditional one is.
 | **Buckets** | | |
 | CreateBucket | ✓ | |
 | DeleteBucket | ✓ | |
-| HeadBucket | ◐ | Requires credentials; `s3:ListBucket` does not expose it anonymously |
+| HeadBucket | ✓ | |
 | ListBuckets | ✓ | |
 | GetBucketLocation | ✓ | |
 | GetBucketVersioning | ✓ | |

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -53,12 +53,16 @@ func (s *s3) routeBucket(w http.ResponseWriter, r *http.Request, accessKeyID *st
 	}
 
 	// routes with optional authentication. The backend rejects an anonymous
-	// listing unless the bucket's policy grants s3:ListBucket.
-	if r.Method == http.MethodGet {
+	// caller unless the bucket's policy grants s3:ListBucket, which covers
+	// listing and HeadBucket.
+	switch r.Method {
+	case http.MethodGet:
 		if q.Get("list-type") == "2" {
 			return s.listObjectsV2(w, r, accessKeyID, bucket)
 		}
 		return s.listObjectsV1(w, r, accessKeyID, bucket)
+	case http.MethodHead:
+		return s.headBucket(w, r, accessKeyID, bucket)
 	}
 
 	// routes with mandatory authentication
@@ -71,8 +75,6 @@ func (s *s3) routeBucket(w http.ResponseWriter, r *http.Request, accessKeyID *st
 		return s.createBucket(w, r, validatedKey, bucket)
 	case http.MethodDelete:
 		return s.deleteBucket(w, r, validatedKey, bucket)
-	case http.MethodHead:
-		return s.headBucket(w, r, validatedKey, bucket)
 	case http.MethodPost:
 		if !q.Has("delete") {
 			return s3errs.ErrNotImplemented // createObjectBrowserUpload is not implemented
@@ -95,7 +97,9 @@ func (s *s3) bucketLocation(w http.ResponseWriter, r *http.Request, accessKeyID 
 	}
 	s.logger.Debug("getting bucket location", zap.String("bucket", bucket))
 
-	if err := s.backend.HeadBucket(r.Context(), validatedKey, bucket); err != nil {
+	// the location is bucket configuration, so it stays owner-only even when a
+	// policy makes the bucket's contents public
+	if err := s.backend.AssertBucketOwner(r.Context(), validatedKey, bucket); err != nil {
 		return err
 	}
 
@@ -147,7 +151,7 @@ func (s *s3) deleteBucket(w http.ResponseWriter, r *http.Request, accessKeyID, b
 // headBucket handles HEAD Bucket requests.
 //
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html
-func (s *s3) headBucket(w http.ResponseWriter, r *http.Request, accessKeyID, bucket string) error {
+func (s *s3) headBucket(w http.ResponseWriter, r *http.Request, accessKeyID *string, bucket string) error {
 	s.logger.Debug("heading bucket", zap.String("bucket", bucket))
 	return s.backend.HeadBucket(r.Context(), accessKeyID, bucket)
 }

--- a/s3/policy.go
+++ b/s3/policy.go
@@ -40,7 +40,7 @@ const (
 	ActionGetObject PolicyActions = 1
 	// ActionGetObjectVersion grants GetObject and HeadObject for a named version.
 	ActionGetObjectVersion PolicyActions = 2
-	// ActionListBucket grants ListObjects.
+	// ActionListBucket grants ListObjects and HeadBucket.
 	ActionListBucket PolicyActions = 4
 	// ActionListBucketVersions grants ListObjectVersions.
 	ActionListBucketVersions PolicyActions = 8

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -140,13 +140,26 @@ type Backend interface {
 	GetObject(ctx context.Context, accessKeyID *string, bucket, object string, version VersionRequest, rnge *ObjectRangeRequest, partNumber *int32) (*Object, error)
 
 	// HeadBucket checks if the bucket with the given name exists and is
-	// accessible for the user identified by the given access key.
+	// readable by the given access key.
 	//
-	// - If the access key does not have permission to access the bucket,
-	//   [ErrAccessDenied] must be returned.
+	// - If the access key does not have permission to read the bucket,
+	//   [ErrAccessDenied] must be returned, unless the bucket's policy grants
+	//   s3:ListBucket to everyone. A 'nil' accessKeyID indicates the anonymous
+	//   user.
+	//
+	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned, except
+	//   to an anonymous caller, which gets [ErrAccessDenied] so it cannot probe
+	//   for buckets it may not read.
+	HeadBucket(ctx context.Context, accessKeyID *string, name string) error
+
+	// AssertBucketOwner checks that the given access key owns the bucket. It
+	// gates the bucket's own configuration, which a policy never opens up.
+	//
+	// - If the bucket is owned by another user, [ErrAccessDenied] must be
+	//   returned.
 	//
 	// - If the bucket does not exist, [ErrNoSuchBucket] must be returned.
-	HeadBucket(ctx context.Context, accessKeyID, name string) error
+	AssertBucketOwner(ctx context.Context, accessKeyID, bucket string) error
 
 	// HeadObject is like GetObject but only retrieves the metadata of the
 	// object and returns an empty body.

--- a/sia/buckets.go
+++ b/sia/buckets.go
@@ -18,9 +18,9 @@ func (s *Sia) DeleteBucket(ctx context.Context, accessKeyID, name string) error 
 	return s.store.DeleteBucket(accessKeyID, name)
 }
 
-// HeadBucket checks if the bucket with the given name exists and is
-// accessible for the user identified by the given access key.
-func (s *Sia) HeadBucket(ctx context.Context, accessKeyID, name string) error {
+// HeadBucket checks that the bucket exists and is readable by the given access
+// key, which is nil for an anonymous caller.
+func (s *Sia) HeadBucket(ctx context.Context, accessKeyID *string, name string) error {
 	return s.store.HeadBucket(accessKeyID, name)
 }
 
@@ -28,6 +28,11 @@ func (s *Sia) HeadBucket(ctx context.Context, accessKeyID, name string) error {
 // given access key.
 func (s *Sia) ListBuckets(ctx context.Context, accessKeyID string) ([]s3.BucketInfo, error) {
 	return s.store.ListBuckets(accessKeyID)
+}
+
+// AssertBucketOwner checks that the given access key owns the bucket.
+func (s *Sia) AssertBucketOwner(ctx context.Context, accessKeyID, bucket string) error {
+	return s.store.AssertBucketOwner(accessKeyID, bucket)
 }
 
 // PutBucketPolicy sets the policy of the bucket, replacing any existing one.

--- a/sia/objects.go
+++ b/sia/objects.go
@@ -261,7 +261,8 @@ func (s *Sia) DeleteObject(ctx context.Context, accessKeyID, bucket string, obje
 // DeleteObjects deletes multiple objects from the specified bucket for the
 // user identified by the given access key.
 func (s *Sia) DeleteObjects(ctx context.Context, accessKeyID, bucket string, objects []s3.ObjectID) (*s3.ObjectsDeleteResult, error) {
-	if err := s.store.HeadBucket(accessKeyID, bucket); err != nil {
+	// an inaccessible bucket fails the whole request rather than every key
+	if err := s.store.AssertBucketOwner(accessKeyID, bucket); err != nil {
 		return nil, err
 	}
 
@@ -450,7 +451,7 @@ func (s *Sia) checkWritePreconditions(accessKeyID, bucket, object string, p s3.O
 // PutObject puts an object with the given key into the specified bucket.
 func (s *Sia) PutObject(ctx context.Context, accessKeyID string, bucket, object string, r io.Reader, opts s3.PutObjectOptions) (_ *s3.PutObjectResult, err error) {
 	// fail fast if the bucket is inaccessible before streaming the body to disk
-	if err := s.store.HeadBucket(accessKeyID, bucket); err != nil {
+	if err := s.store.AssertBucketOwner(accessKeyID, bucket); err != nil {
 		return nil, err
 	}
 

--- a/sia/persist/sqlite/buckets.go
+++ b/sia/persist/sqlite/buckets.go
@@ -62,11 +62,20 @@ func (s *Store) DeleteBucket(accessKeyID, bucket string) error {
 	})
 }
 
-// HeadBucket verifies that the bucket exists and is owned by the user
-// associated with the given access key.
-func (s *Store) HeadBucket(accessKeyID, bucket string) error {
+// AssertBucketOwner verifies that the given access key owns the bucket. It also
+// gates bucket configuration, which a policy never opens up.
+func (s *Store) AssertBucketOwner(accessKeyID, bucket string) error {
 	return s.transaction(func(tx *txn) error {
 		_, err := bucketID(tx, accessKeyID, bucket)
+		return err
+	})
+}
+
+// HeadBucket verifies that the caller may read the bucket. S3 authorizes it
+// with s3:ListBucket, which a policy may grant to everyone.
+func (s *Store) HeadBucket(accessKeyID *string, bucket string) error {
+	return s.transaction(func(tx *txn) error {
+		_, err := bucketForRead(tx, accessKeyID, bucket, s3.ActionListBucket)
 		return err
 	})
 }

--- a/sia/persist/sqlite/users_test.go
+++ b/sia/persist/sqlite/users_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/SiaFoundation/s3d/s3/s3errs"
 	"github.com/SiaFoundation/s3d/sia"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -186,12 +187,12 @@ func TestBucketOwnership(t *testing.T) {
 	}
 
 	// alice can head her bucket
-	if err := store.HeadBucket("ALICE_KEY", "shared-name"); err != nil {
+	if err := store.HeadBucket(aws.String("ALICE_KEY"), "shared-name"); err != nil {
 		t.Fatal(err)
 	}
 
 	// bob gets access denied on head
-	if err := store.HeadBucket("BOB_KEY", "shared-name"); !errors.Is(err, s3errs.ErrAccessDenied) {
+	if err := store.HeadBucket(aws.String("BOB_KEY"), "shared-name"); !errors.Is(err, s3errs.ErrAccessDenied) {
 		t.Fatal("expected ErrAccessDenied", err)
 	}
 
@@ -226,7 +227,7 @@ func TestBucketOwnership(t *testing.T) {
 	}
 
 	// verify it is gone
-	if err := store.HeadBucket("ALICE_KEY", "shared-name"); !errors.Is(err, s3errs.ErrNoSuchBucket) {
+	if err := store.HeadBucket(aws.String("ALICE_KEY"), "shared-name"); !errors.Is(err, s3errs.ErrNoSuchBucket) {
 		t.Fatal("expected ErrNoSuchBucket", err)
 	}
 }

--- a/sia/policy_test.go
+++ b/sia/policy_test.go
@@ -171,6 +171,10 @@ func TestBucketPolicyPublicReadScope(t *testing.T) {
 	}
 
 	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		// a HEAD response carries no body, so only its status is checkable.
+		// s3:ListBucket also authorizes HeadBucket, and is not granted here.
+		testutil.AssertS3StatusCode(t, s3errs.ErrAccessDenied, c.client.HeadBucket(t.Context(), bucket))
+
 		tests := []struct {
 			name string
 			do   func() error
@@ -399,6 +403,11 @@ func TestBucketPolicyPublicListAndVersions(t *testing.T) {
 	}
 
 	// ListObjects v1 and v2
+	// s3:ListBucket also authorizes HeadBucket
+	if err := anon.HeadBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+
 	v1, err := anon.ListObjects(t.Context(), bucket, nil, nil, s3.ListObjectsPage{})
 	if err != nil {
 		t.Fatal(err)
@@ -750,4 +759,35 @@ func TestBucketPolicyDeleteMarkerHidden(t *testing.T) {
 		_, err := c.client.GetObjectVersion(t.Context(), bucket, object, nil)
 		testutil.AssertS3StatusCode(t, s3errs.ErrNoSuchKey, err)
 	})
+}
+
+// TestBucketPolicyKeepsConfigurationPrivate checks that a public bucket's own
+// configuration stays owner-only.
+func TestBucketPolicyKeepsConfigurationPrivate(t *testing.T) {
+	const bucket = "bucket"
+
+	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
+	other := s3Tester.ChangeAccessKey(t, otherAccessKeyID, otherSecretKey)
+
+	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	} else if err := s3Tester.PutBucketPolicy(t.Context(), bucket, readAndListPolicy(bucket)); err != nil {
+		t.Fatal(err)
+	}
+
+	// the owner can still read it
+	if _, err := s3Tester.BucketLocation(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	// s3:ListBucket lets the other user head and list the bucket, but not read
+	// its configuration
+	if err := other.HeadBucket(t.Context(), bucket); err != nil {
+		t.Fatal(err)
+	}
+	_, err := other.BucketLocation(t.Context(), bucket)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+
+	_, err = other.GetBucketVersioning(t.Context(), bucket)
+	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
 }

--- a/sia/policy_test.go
+++ b/sia/policy_test.go
@@ -767,7 +767,6 @@ func TestBucketPolicyKeepsConfigurationPrivate(t *testing.T) {
 	const bucket = "bucket"
 
 	s3Tester := testutil.NewTester(t, testutil.WithKeyPair("other", otherAccessKeyID, otherSecretKey))
-	other := s3Tester.ChangeAccessKey(t, otherAccessKeyID, otherSecretKey)
 
 	if err := s3Tester.CreateBucket(t.Context(), bucket); err != nil {
 		t.Fatal(err)
@@ -780,14 +779,16 @@ func TestBucketPolicyKeepsConfigurationPrivate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// s3:ListBucket lets the other user head and list the bucket, but not read
-	// its configuration
-	if err := other.HeadBucket(t.Context(), bucket); err != nil {
-		t.Fatal(err)
-	}
-	_, err := other.BucketLocation(t.Context(), bucket)
-	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+	forEachPublicCaller(t, s3Tester, func(t *testing.T, c publicCaller) {
+		// s3:ListBucket lets the caller head the bucket, but not read its
+		// configuration
+		if err := c.client.HeadBucket(t.Context(), bucket); err != nil {
+			t.Fatal(err)
+		}
+		_, err := c.client.BucketLocation(t.Context(), bucket)
+		testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
 
-	_, err = other.GetBucketVersioning(t.Context(), bucket)
-	testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+		_, err = c.client.GetBucketVersioning(t.Context(), bucket)
+		testutil.AssertS3Error(t, s3errs.ErrAccessDenied, err)
+	})
 }

--- a/sia/sia.go
+++ b/sia/sia.go
@@ -187,7 +187,8 @@ type Store interface {
 	DeleteObject(accessKeyID, bucket string, objectID s3.ObjectID) (string, bool, objects.OrphanedFile, error)
 	GetObject(accessKeyID *string, bucket, object string, version s3.VersionRequest, partNumber *int32, action s3.PolicyActions) (*objects.Object, error)
 	DiskUsage() (uint64, error)
-	HeadBucket(accessKeyID, bucket string) error
+	HeadBucket(accessKeyID *string, bucket string) error
+	AssertBucketOwner(accessKeyID, bucket string) error
 	GetBucketVersioning(accessKeyID, bucket string) (string, error)
 	PutBucketVersioning(accessKeyID, bucket, status string) error
 	GetBucketPolicy(accessKeyID, bucket string) (s3.BucketPolicy, error)


### PR DESCRIPTION
`HeadBucket` should be possible if `s3:ListBucket` is granted.

https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html

